### PR TITLE
[Fix, Refactor] 자기소개서 부분 API 수정

### DIFF
--- a/src/apps/server/resumes/controllers/question.controller.ts
+++ b/src/apps/server/resumes/controllers/question.controller.ts
@@ -1,6 +1,7 @@
 import { UseGuards, HttpStatus, Param, Body, ParseIntPipe, Controller } from '@nestjs/common';
 import { ApiTags } from '@nestjs/swagger';
 import { Method } from '📚libs/enums/method.enum';
+import { SpellCheckResult } from '📚libs/modules/api/api.type';
 import { ResponseEntity } from '📚libs/utils/respone.entity';
 import { UserJwtToken } from '🔥apps/server/auth/types/jwt-tokwn.type';
 import { User } from '🔥apps/server/common/decorators/request/user.decorator';
@@ -9,6 +10,7 @@ import { JwtAuthGuard } from '🔥apps/server/common/guards/jwt-auth.guard';
 import { GetOneQuestionRequestParamDto, GetOneQuestionResponseDto } from '🔥apps/server/resumes/dtos/get-question.dto';
 import { PatchQuestionRequestParamDto, PatchQuestionRequestBodyDto } from '🔥apps/server/resumes/dtos/patch-question-request.dto';
 import { PostQuestionResponseDto, PostQuestionRequestBodyDto } from '🔥apps/server/resumes/dtos/post-question.dto';
+import { PostSpellCheckRequestBodyDto } from '🔥apps/server/resumes/dtos/post-spell-check-request.body.dto';
 import { QuestionsService } from '🔥apps/server/resumes/services/question.service';
 
 @ApiTags('📑 자기소개서 문항 API')
@@ -36,6 +38,27 @@ export class QuestionsController {
     const question = await this.questionService.createOneQuestion(user.userId, postQuestionRequestParamDto.resumeId);
 
     return ResponseEntity.CREATED_WITH_DATA(question);
+  }
+
+  @Route({
+    request: {
+      path: 'spell-check',
+      method: Method.POST,
+    },
+    response: {
+      code: HttpStatus.OK,
+      description: '자기소개서 맞춤법 검사에 성공했습니다. 다음 맞춤법 검사의 결과입니다.',
+      type: SpellCheckResult,
+      isArray: true,
+    },
+    summary: '자기소개서 답안 맞춤법 검사 API',
+    description:
+      '# 자기소개서 답안 맞춤법 검사 API\n## Description\n맞춤법을 검사하여 맞춤법에 맞지 않은 토큰을 모두 반환합니다.\n## etc.\n⛳️ [맞춤법 검사-로딩...](https://www.figma.com/file/0ZJ1ulwtU8k0KQuroxU9Wc/%EC%9D%B8%EC%82%AC%EC%9D%B4%ED%8A%B8%EC%95%84%EC%9B%83?type=design&node-id=1263-19185&t=zKwSWoPmdDHGzQV4-4)   \n⛳️ [맞춤법 검사-오류 없음](https://www.figma.com/file/0ZJ1ulwtU8k0KQuroxU9Wc/%EC%9D%B8%EC%82%AC%EC%9D%B4%ED%8A%B8%EC%95%84%EC%9B%83?type=design&node-id=1263-19553&t=zKwSWoPmdDHGzQV4-4)   \n⛳️ [맞춤법 검사 - 오류 있음](https://www.figma.com/file/0ZJ1ulwtU8k0KQuroxU9Wc/%EC%9D%B8%EC%82%AC%EC%9D%B4%ED%8A%B8%EC%95%84%EC%9B%83?type=design&node-id=1221-11498&t=zKwSWoPmdDHGzQV4-4)   \n⛳️ [맞춤법 검사-오류 보기](https://www.figma.com/file/0ZJ1ulwtU8k0KQuroxU9Wc/%EC%9D%B8%EC%82%AC%EC%9D%B4%ED%8A%B8%EC%95%84%EC%9B%83?type=design&node-id=1263-20990&t=zKwSWoPmdDHGzQV4-4)',
+  })
+  async spellCheck(@Body() body: PostSpellCheckRequestBodyDto) {
+    const checkedSpell = await this.questionService.spellCheck(body);
+
+    return ResponseEntity.OK_WITH_DATA(checkedSpell);
   }
 
   /**

--- a/src/apps/server/resumes/controllers/question.controller.ts
+++ b/src/apps/server/resumes/controllers/question.controller.ts
@@ -7,6 +7,11 @@ import { UserJwtToken } from '🔥apps/server/auth/types/jwt-tokwn.type';
 import { User } from '🔥apps/server/common/decorators/request/user.decorator';
 import { Route } from '🔥apps/server/common/decorators/router/route.decorator';
 import { JwtAuthGuard } from '🔥apps/server/common/guards/jwt-auth.guard';
+import {
+  PostSpellCheckDescriptionMd,
+  PostSpellCheckResponseDescriptionMd,
+  PostSpellCheckSummaryMd,
+} from '🔥apps/server/resumes/docs/post-spell-check.doc';
 import { GetOneQuestionRequestParamDto, GetOneQuestionResponseDto } from '🔥apps/server/resumes/dtos/get-question.dto';
 import { PatchQuestionRequestParamDto, PatchQuestionRequestBodyDto } from '🔥apps/server/resumes/dtos/patch-question-request.dto';
 import { PostQuestionResponseDto, PostQuestionRequestBodyDto } from '🔥apps/server/resumes/dtos/post-question.dto';
@@ -47,13 +52,12 @@ export class QuestionsController {
     },
     response: {
       code: HttpStatus.OK,
-      description: '자기소개서 맞춤법 검사에 성공했습니다. 다음 맞춤법 검사의 결과입니다.',
+      description: PostSpellCheckResponseDescriptionMd,
       type: SpellCheckResult,
       isArray: true,
     },
-    summary: '자기소개서 답안 맞춤법 검사 API',
-    description:
-      '# 자기소개서 답안 맞춤법 검사 API\n## Description\n맞춤법을 검사하여 맞춤법에 맞지 않은 토큰을 모두 반환합니다.\n## etc.\n⛳️ [맞춤법 검사-로딩...](https://www.figma.com/file/0ZJ1ulwtU8k0KQuroxU9Wc/%EC%9D%B8%EC%82%AC%EC%9D%B4%ED%8A%B8%EC%95%84%EC%9B%83?type=design&node-id=1263-19185&t=zKwSWoPmdDHGzQV4-4)   \n⛳️ [맞춤법 검사-오류 없음](https://www.figma.com/file/0ZJ1ulwtU8k0KQuroxU9Wc/%EC%9D%B8%EC%82%AC%EC%9D%B4%ED%8A%B8%EC%95%84%EC%9B%83?type=design&node-id=1263-19553&t=zKwSWoPmdDHGzQV4-4)   \n⛳️ [맞춤법 검사 - 오류 있음](https://www.figma.com/file/0ZJ1ulwtU8k0KQuroxU9Wc/%EC%9D%B8%EC%82%AC%EC%9D%B4%ED%8A%B8%EC%95%84%EC%9B%83?type=design&node-id=1221-11498&t=zKwSWoPmdDHGzQV4-4)   \n⛳️ [맞춤법 검사-오류 보기](https://www.figma.com/file/0ZJ1ulwtU8k0KQuroxU9Wc/%EC%9D%B8%EC%82%AC%EC%9D%B4%ED%8A%B8%EC%95%84%EC%9B%83?type=design&node-id=1263-20990&t=zKwSWoPmdDHGzQV4-4)',
+    summary: PostSpellCheckSummaryMd,
+    description: PostSpellCheckDescriptionMd,
   })
   async spellCheck(@Body() body: PostSpellCheckRequestBodyDto) {
     const checkedSpell = await this.questionService.spellCheck(body);

--- a/src/apps/server/resumes/controllers/resumes.controller.ts
+++ b/src/apps/server/resumes/controllers/resumes.controller.ts
@@ -1,7 +1,6 @@
 import { UseGuards, Controller, Query, HttpStatus, Body, Param, ParseIntPipe } from '@nestjs/common';
-import { ApiTags, ApiOkResponse, ApiQuery, ApiParam } from '@nestjs/swagger';
+import { ApiTags, ApiQuery, ApiParam } from '@nestjs/swagger';
 import { Method } from '📚libs/enums/method.enum';
-import { SpellCheckResult } from '📚libs/modules/api/api.type';
 import { ResponseEntity } from '📚libs/utils/respone.entity';
 import { UserJwtToken } from '🔥apps/server/auth/types/jwt-tokwn.type';
 import { User } from '🔥apps/server/common/decorators/request/user.decorator';
@@ -26,7 +25,6 @@ import {
 } from '🔥apps/server/resumes/dtos/get-resume.dto';
 import { PatchResumeRequestDto } from '🔥apps/server/resumes/dtos/patch-resume.dto';
 import { PostResumeResponseDto } from '🔥apps/server/resumes/dtos/post-resume.dto';
-import { PostSpellCheckRequestBodyDto } from '🔥apps/server/resumes/dtos/post-spell-check-request.body.dto';
 import { ResumesService } from '🔥apps/server/resumes/services/resumes.service';
 
 @ApiTags('🗂️ 자기소개서 API')
@@ -145,30 +143,6 @@ export class ResumesController {
     const resume = await this.resumesService.createResumeFolder(user.userId);
 
     return ResponseEntity.CREATED_WITH_DATA(resume);
-  }
-
-  @Route({
-    request: {
-      path: 'spell-check',
-      method: Method.POST,
-    },
-    response: {
-      code: HttpStatus.OK,
-      description: '자기소개서 맞춤법 검사에 성공했습니다. 다음 맞춤법 검사의 결과입니다.',
-      type: SpellCheckResult,
-      isArray: true,
-    },
-    summary: '자기소개서 답안 맞춤법 검사 API',
-    description:
-      '# 자기소개서 답안 맞춤법 검사 API\n## Description\n맞춤법을 검사하여 맞춤법에 맞지 않은 토큰을 모두 반환합니다.\n## etc.\n⛳️ [맞춤법 검사-로딩...](https://www.figma.com/file/0ZJ1ulwtU8k0KQuroxU9Wc/%EC%9D%B8%EC%82%AC%EC%9D%B4%ED%8A%B8%EC%95%84%EC%9B%83?type=design&node-id=1263-19185&t=zKwSWoPmdDHGzQV4-4)   \n⛳️ [맞춤법 검사-오류 없음](https://www.figma.com/file/0ZJ1ulwtU8k0KQuroxU9Wc/%EC%9D%B8%EC%82%AC%EC%9D%B4%ED%8A%B8%EC%95%84%EC%9B%83?type=design&node-id=1263-19553&t=zKwSWoPmdDHGzQV4-4)   \n⛳️ [맞춤법 검사 - 오류 있음](https://www.figma.com/file/0ZJ1ulwtU8k0KQuroxU9Wc/%EC%9D%B8%EC%82%AC%EC%9D%B4%ED%8A%B8%EC%95%84%EC%9B%83?type=design&node-id=1221-11498&t=zKwSWoPmdDHGzQV4-4)   \n⛳️ [맞춤법 검사-오류 보기](https://www.figma.com/file/0ZJ1ulwtU8k0KQuroxU9Wc/%EC%9D%B8%EC%82%AC%EC%9D%B4%ED%8A%B8%EC%95%84%EC%9B%83?type=design&node-id=1263-20990&t=zKwSWoPmdDHGzQV4-4)',
-  })
-  @ApiOkResponse({
-    description: '맞춤법 조회 결과를 반환합니다.',
-  })
-  async spellCheck(@Body() body: PostSpellCheckRequestBodyDto) {
-    const checkedSpell = await this.resumesService.spellCheck(body);
-
-    return ResponseEntity.OK_WITH_DATA(checkedSpell);
   }
 
   @Route({

--- a/src/apps/server/resumes/controllers/resumes.controller.ts
+++ b/src/apps/server/resumes/controllers/resumes.controller.ts
@@ -112,7 +112,7 @@ export class ResumesController {
       description:
         '### ✅ 특정 자기소개서 조회에 성공했습니다.\n한 개의 자기소개서를 가져오며, 자기소개서에 속한 자기소개서 문항도 생성일자 기준 내림차순으로 가져옵니다.',
     },
-    summary: '특정 자기소개서 조회 API (2023.6.3. Updated)',
+    summary: '특정 자기소개서 조회 API (2023.6.6. Updated)',
     description: `# 자기소개서 조회 API\n## Description\n**userId**와 **resumeId** path parameter를 통해서 특정 자기소개서 한 개를 조회합니다. 자기소개서는 그 자기소개서에 속한 모든 문항를 가져옵니다.   \n자기소개서 문항은 **생성일자 기준 내림차순(최신순)으로 정렬**되어 출력됩니다. 주로 \`모아보기\`에서 사용됩니다.\n## Picture\n![image](https://github.com/depromeet/13th-4team-backend/assets/83271772/90712fb4-7c1e-4b8c-845e-2139dd6deca9)\n## Figma.\n⛳️ [자기소개서 모아보기](https://www.figma.com/file/0ZJ1ulwtU8k0KQuroxU9Wc/%EC%9D%B8%EC%82%AC%EC%9D%B4%ED%8A%B8%EC%95%84%EC%9B%83?type=design&node-id=1403-11728&t=oMTkLrgQjXJOPb8D-4)`,
   })
   public async getOneResume(

--- a/src/apps/server/resumes/docs/post-spell-check.doc.ts
+++ b/src/apps/server/resumes/docs/post-spell-check.doc.ts
@@ -1,0 +1,52 @@
+export const PostSpellCheckResponseDescriptionMd = `
+### ✅ 자기소개서 맞춤법 검사에 성공했습니다.
+다음 맞춤법 검사기를 연동하여 요청을 보낸 결과입니다.
+`;
+
+export const PostSpellCheckSummaryMd = `
+자기소개서 답안 맞춤법 검사 API
+`;
+
+export const PostSpellCheckDescriptionMd = `
+# 자기소개서 답안 맞춤법 검사 API
+
+## Description
+
+맞춤법을 검사하여 맞춤법에 맞지 않은 토큰을 모두 반환합니다.
+
+아래는 응답 예시입니다.
+
+\`\`\`ts
+[
+    [
+        {
+            "type": "space",
+            "token": "일년에",
+            "suggestions": [
+                "일 년에"
+            ],
+            "context": "최초로 시작되어 일년에 한바퀴를 돌면서"
+        }
+    ]
+]
+\`\`\`
+
+**type**은 틀린 맞춤법의 유형입니다. \`space\`는 띄어쓰기, \`spell\`은 전반적으로 틀린 맞춤법 (ex.돼게 -> 되게, 역활 -> 역할), \`doubt\`는 맞춤법 오류가 의심되는 구절입니다. 명세를 확인할 수 없어서 추가적인 오류 타입이 존재할 수도 있습니다.
+
+**token**은 틀린 맞춤법의 토큰(글자)입니다.
+
+**suggestions**는 틀린 맞춤법에 대해서 정정할 수 있는 방법들입니다.
+
+**context**는 틀린 맞춤법 토큰이 어떤 맥락에서 틀린 것인지를 나타냅니다.
+
+## Picture
+
+<img width="431" alt="image" src="https://github.com/depromeet/13th-4team-backend/assets/83271772/77289549-80ed-4c14-9e08-1cc0668f70a9">
+
+## Figma
+
+⛳️ [맞춤법 검사-로딩...](https://www.figma.com/file/0ZJ1ulwtU8k0KQuroxU9Wc/%EC%9D%B8%EC%82%AC%EC%9D%B4%ED%8A%B8%EC%95%84%EC%9B%83?type=design&node-id=1263-19185&t=zKwSWoPmdDHGzQV4-4)\n
+⛳️ [맞춤법 검사-오류 없음](https://www.figma.com/file/0ZJ1ulwtU8k0KQuroxU9Wc/%EC%9D%B8%EC%82%AC%EC%9D%B4%ED%8A%B8%EC%95%84%EC%9B%83?type=design&node-id=1263-19553&t=zKwSWoPmdDHGzQV4-4)\n
+⛳️ [맞춤법 검사 - 오류 있음](https://www.figma.com/file/0ZJ1ulwtU8k0KQuroxU9Wc/%EC%9D%B8%EC%82%AC%EC%9D%B4%ED%8A%B8%EC%95%84%EC%9B%83?type=design&node-id=1221-11498&t=zKwSWoPmdDHGzQV4-4)\n
+⛳️ [맞춤법 검사-오류 보기](https://www.figma.com/file/0ZJ1ulwtU8k0KQuroxU9Wc/%EC%9D%B8%EC%82%AC%EC%9D%B4%ED%8A%B8%EC%95%84%EC%9B%83?type=design&node-id=1263-20990&t=zKwSWoPmdDHGzQV4-4)
+`;

--- a/src/apps/server/resumes/dtos/get-resume.dto.ts
+++ b/src/apps/server/resumes/dtos/get-resume.dto.ts
@@ -113,7 +113,7 @@ export class GetOneResumeResponseDto {
     this._createdAt = resume.createdAt;
     this._updatedAt = resume.updatedAt;
     this._question = resume.Question.map((question) => {
-      const { resumeId, createdAt, ...rest } = question;
+      const { resumeId, ...rest } = question;
       return rest;
     });
   }

--- a/src/apps/server/resumes/dtos/patch-question-request.dto.ts
+++ b/src/apps/server/resumes/dtos/patch-question-request.dto.ts
@@ -1,13 +1,6 @@
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { Type } from 'class-transformer';
-import {
-  IsInt,
-  IsNotEmpty,
-  IsOptional,
-  IsPositive,
-  IsString,
-  MaxLength,
-} from 'class-validator';
+import { IsInt, IsNotEmpty, IsOptional, IsPositive, IsString, MaxLength } from 'class-validator';
 
 export class PatchQuestionRequestParamDto {
   @ApiProperty({
@@ -28,6 +21,7 @@ export class PatchQuestionRequestBodyDto {
   @IsString()
   @IsNotEmpty()
   @IsOptional()
+  @MaxLength(300)
   title?: string | undefined;
 
   @ApiPropertyOptional({
@@ -37,6 +31,6 @@ export class PatchQuestionRequestBodyDto {
   @IsString()
   @IsNotEmpty()
   @IsOptional()
-  @MaxLength(2000)
+  @MaxLength(2500)
   answer?: string | undefined;
 }

--- a/src/apps/server/resumes/dtos/patch-resume.dto.ts
+++ b/src/apps/server/resumes/dtos/patch-resume.dto.ts
@@ -1,5 +1,5 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { IsNotEmpty, IsString } from 'class-validator';
+import { IsNotEmpty, IsString, MaxLength } from 'class-validator';
 
 export class PatchResumeRequestDto {
   @ApiProperty({
@@ -9,5 +9,6 @@ export class PatchResumeRequestDto {
   })
   @IsString()
   @IsNotEmpty()
+  @MaxLength(13)
   title: string;
 }

--- a/src/apps/server/resumes/dtos/post-spell-check-request.body.dto.ts
+++ b/src/apps/server/resumes/dtos/post-spell-check-request.body.dto.ts
@@ -9,6 +9,6 @@ export class PostSpellCheckRequestBodyDto {
   })
   @IsString()
   @IsNotEmpty()
-  @MaxLength(2000)
+  @MaxLength(2500)
   sentence: string;
 }

--- a/src/apps/server/resumes/services/question.service.ts
+++ b/src/apps/server/resumes/services/question.service.ts
@@ -4,10 +4,17 @@ import { ResumeRepository } from '📚libs/modules/database/repositories/resume.
 import { PostQuestionResponseDto } from '../dtos/post-question.dto';
 import { PatchQuestionRequestBodyDto } from '🔥apps/server/resumes/dtos/patch-question-request.dto';
 import { GetOneQuestionResponseDto } from '🔥apps/server/resumes/dtos/get-question.dto';
+import { PostSpellCheckRequestBodyDto } from '🔥apps/server/resumes/dtos/post-spell-check-request.body.dto';
+import { SpellCheckResult } from '📚libs/modules/api/api.type';
+import { ApiService } from '📚libs/modules/api/api.service';
 
 @Injectable()
 export class QuestionsService {
-  constructor(private readonly resumeRepository: ResumeRepository, private readonly questionRepository: QuestionRepository) {}
+  constructor(
+    private readonly resumeRepository: ResumeRepository,
+    private readonly questionRepository: QuestionRepository,
+    private readonly apiService: ApiService,
+  ) {}
 
   /**
    * 자기소개서의 문항을 한 개 생성합니다.
@@ -30,6 +37,13 @@ export class QuestionsService {
 
     const questionReponseDto = new PostQuestionResponseDto(question);
     return questionReponseDto;
+  }
+
+  public async spellCheck(body: PostSpellCheckRequestBodyDto): Promise<SpellCheckResult[][]> {
+    const { sentence } = body;
+    const checkedSpellByDAUM = await this.apiService.spellCheckByDaum(sentence);
+
+    return checkedSpellByDAUM;
   }
 
   async updateOneQuestion(body: PatchQuestionRequestBodyDto, questionId: number, userId: number): Promise<void> {

--- a/src/apps/server/resumes/services/resumes.service.ts
+++ b/src/apps/server/resumes/services/resumes.service.ts
@@ -68,8 +68,14 @@ export class ResumesService {
   public async getOneResume(userId: number, resumeId: number): Promise<GetOneResumeResponseDto> {
     const resume = await this.resumesRepository.findFirst({
       where: { userId, id: resumeId },
-      include: { Question: { select: { id: true, title: true, answer: true, updatedAt: true }, orderBy: { createdAt: 'desc' } } }, // 자기소개서 문항을 left join, select 하며, 생성일자 기준 내림차순으로 모두 가져옵니다.
+      include: {
+        Question: { select: { id: true, title: true, answer: true, createdAt: true, updatedAt: true }, orderBy: { createdAt: 'desc' } },
+      }, // 자기소개서 문항을 left join, select 하며, 생성일자 기준 내림차순으로 모두 가져옵니다.
     });
+
+    if (!resume) {
+      throw new NotFoundException('Resume not found');
+    }
 
     // Entity -> DTO
     const getOneResumeDto = new GetOneResumeResponseDto(resume as Resume & { Question: Question[] });

--- a/src/apps/server/resumes/services/resumes.service.ts
+++ b/src/apps/server/resumes/services/resumes.service.ts
@@ -1,5 +1,3 @@
-import { ApiService } from '📚libs/modules/api/api.service';
-import { SpellCheckResult } from '📚libs/modules/api/api.type';
 import { ResumeRepository } from '📚libs/modules/database/repositories/resume.repository';
 import { Injectable, NotFoundException } from '@nestjs/common';
 import {
@@ -9,18 +7,13 @@ import {
 } from '🔥apps/server/resumes/dtos/get-resume.dto';
 import { PatchResumeRequestDto } from '🔥apps/server/resumes/dtos/patch-resume.dto';
 import { PostResumeResponseDto } from '🔥apps/server/resumes/dtos/post-resume.dto';
-import { PostSpellCheckRequestBodyDto } from '🔥apps/server/resumes/dtos/post-spell-check-request.body.dto';
 import { Question, Resume } from '@prisma/client';
 import { PrismaService } from '📚libs/modules/database/prisma.service';
 import { GetCountOfResumeResponseDto } from '🔥apps/server/resumes/dtos/get-count-of-resume.dto';
 
 @Injectable()
 export class ResumesService {
-  constructor(
-    private readonly resumesRepository: ResumeRepository,
-    private readonly apiService: ApiService,
-    private readonly prisma: PrismaService,
-  ) {}
+  constructor(private readonly resumesRepository: ResumeRepository, private readonly prisma: PrismaService) {}
 
   /**
    * 유저가 작성한 모든 자기소개서를 가져옵니다. 문항의 답안(answer)은 payload가 크기 때문에 option으로 선택해 가져옵니다.
@@ -110,13 +103,6 @@ export class ResumesService {
     // Entity -> DTO
     const resumeResponseDto = new PostResumeResponseDto(resume);
     return resumeResponseDto;
-  }
-
-  public async spellCheck(body: PostSpellCheckRequestBodyDto): Promise<SpellCheckResult[][]> {
-    const { sentence } = body;
-    const checkedSpellByDAUM = await this.apiService.spellCheckByDaum(sentence);
-
-    return checkedSpellByDAUM;
   }
 
   async deleteResume({ resumeId, userId }: { resumeId: number; userId: number }): Promise<void> {

--- a/src/libs/modules/api/api.service.ts
+++ b/src/libs/modules/api/api.service.ts
@@ -49,13 +49,13 @@ export class ApiService {
   }
 
   /**
-   * 주어진 문장을 2000글자 단위로 나눠서 맞춤법 검사를 진행합니다.
+   * 주어진 문장을 2500글자 단위로 나눠서 맞춤법 검사를 진행합니다.
    * @param sentence 입력된 글
    * @returns 글에서 맞춤법오류 종류, 맞춤법 오류 토큰, 정정 토큰, 맞춤법이 틀린 곳의 문장, 정정 이유를 배열로 반환합니다.
    */
   async spellCheckByDaum(sentence: string): Promise<SpellCheckResult[][]> {
     const DAUM_URL = 'https://dic.daum.net/grammar_checker.do';
-    const DAUM_MAX_CHARS = 2000;
+    const DAUM_MAX_CHARS = 2500;
 
     // Removes HTML tags.
     sentence = sentence.replace(/<[^ㄱ-ㅎㅏ-ㅣ가-힣>]+>/g, '');

--- a/src/libs/modules/database/schema.prisma
+++ b/src/libs/modules/database/schema.prisma
@@ -87,10 +87,10 @@ model UserInfo {
 model Onboarding {
   userId Int @id
 
-  experience Boolean @default(false) // 경험분해 온보딩 여부
+  experience        Boolean @default(false) // 경험분해 온보딩 여부
   experienceStepper Boolean @default(false) @map("experience_stepper") // 경험분해 stepper 온보딩 여부
-  resume Boolean @default(false) // 자기소개서 작성 온보딩 여부
-  collection Boolean @default(false) // 모아보기 온보딩 여부
+  resume            Boolean @default(false) // 자기소개서 작성 온보딩 여부
+  collection        Boolean @default(false) // 모아보기 온보딩 여부
 
   User User @relation(references: [id], fields: [userId])
 
@@ -104,7 +104,7 @@ model Onboarding {
 // 자기소개서 제목
 model Resume {
   id    Int    @id @default(autoincrement())
-  title String @db.VarChar(13) @default("새 자기소개서") // 자기소개서 제목
+  title String @default("새 자기소개서") @db.VarChar(13) // 자기소개서 제목
 
   createdAt DateTime @default(now()) @map("created_at") @db.Timestamptz
   updatedAt DateTime @updatedAt @map("updated_at") @db.Timestamptz
@@ -124,7 +124,7 @@ model Question {
   id       Int @id @default(autoincrement())
   resumeId Int @map("resume_id") // 자기소개서 제목 pfk
 
-  title  String?  @db.VarChar(300) // 문항 제목
+  title  String? @db.VarChar(300) // 문항 제목
   answer String? @db.VarChar(2500) // 문항 내용
 
   createdAt DateTime @default(now()) @map("created_at") @db.Timestamptz
@@ -224,7 +224,7 @@ model Capability {
 }
 
 model ExperienceCapability {
-  experienceId  Int @map("experience_id")
+  experienceId Int @map("experience_id")
   capabilityId Int @map("capability_id")
 
   Experience Experience @relation(references: [id], fields: [experienceId])

--- a/src/libs/utils/hanspell.function.ts
+++ b/src/libs/utils/hanspell.function.ts
@@ -114,11 +114,7 @@ export const parseJSON = (response: any) => {
  * @param limit 최대 길이
  * @returns 구분자 및 최대 길이로 나뉘어진 글 배열을 반환합니다.
  */
-export const byLength = (
-  string: string,
-  separator: string,
-  limit: number,
-): string[] => {
+export const byLength = (string: string, separator: string, limit: number): string[] => {
   const splitted: string[] = [];
   let lastFound = -1;
   let lastSplitted = -1;
@@ -192,7 +188,7 @@ export const parseJSONFromDaum = (
       token: '',
       suggestions: [],
       context: '',
-      info: '',
+      // info: '',
     };
 
     typo.type = decode(getAttr(line, 'data-error-type='));
@@ -209,16 +205,16 @@ export const parseJSONFromDaum = (
       infoEnd = infoNextEnd;
     }
 
-    typo.info = decode(response.substr(infoBegin, infoEnd + 6 - infoBegin))
-      .replace(/\t/g, '')
-      .replace(/<strong class[^>]*>[^>]*>\n/gi, '')
-      .replace(/<br[^>]*>/gi, '\n')
-      .replace(/<[^>]*>/g, '')
-      .replace(/\n\n\n\n\n/g, '\n(예)\n')
-      .replace(/\n\n*$/g, '')
-      .replace(/^[ \n][ \n]*/g, '');
+    // typo.info = decode(response.substr(infoBegin, infoEnd + 6 - infoBegin))
+    //   .replace(/\t/g, '')
+    //   .replace(/<strong class[^>]*>[^>]*>\n/gi, '')
+    //   .replace(/<br[^>]*>/gi, '\n')
+    //   .replace(/<[^>]*>/g, '')
+    //   .replace(/\n\n\n\n\n/g, '\n(예)\n')
+    //   .replace(/\n\n*$/g, '')
+    //   .replace(/^[ \n][ \n]*/g, '');
 
-    if (typo.info === '도움말이 없습니다.') delete typo.info;
+    // if (typo.info === '도움말이 없습니다.') delete typo.info;
 
     typos.push(typo);
   }


### PR DESCRIPTION
## ⛳️ 기능 구현 배경

---

<!-- 기능 구현 배경에 대해 작성해주세요 -->

- 문항 조회에 createdAt 추가
- 특정 자기소개서 조회 실패 시 예외 처리 추가
- 문항 별 maxLength 수정
- 맞춤법 검사 API 경로 수정

## 😤 기능 구현 내용(Optional)

---

<!-- 기능 구현 내용에 대해 적어주세요 -->

```ts
  public async getOneResume(userId: number, resumeId: number): Promise<GetOneResumeResponseDto> {
    const resume = await this.resumesRepository.findFirst({
      where: { userId, id: resumeId },
      include: {
        Question: { select: { id: true, title: true, answer: true, createdAt: true, updatedAt: true }, orderBy: { createdAt: 'desc' } },
      }, // 자기소개서 문항을 left join, select 하며, 생성일자 기준 내림차순으로 모두 가져옵니다.
    });

    if (!resume) {
      throw new NotFoundException('Resume not found');
    }

    // Entity -> DTO
    const getOneResumeDto = new GetOneResumeResponseDto(resume as Resume & { Question: Question[] });
    return getOneResumeDto;
  }
```

자기소개서가 없으면 예외를 일으킵니다.

## 📭 이슈 번호

---

<!-- 이슈 번호를 남겨주세요 -->

#130 

## 🧐 의견 구하기

---

<!-- 구하고 싶은 의견이 있다면 작성해주세요 -->

## 🙏 P.S

---

<!-- 추가적으로 남기고 싶은 말을 적어주세요 -->
