### PR TITLE
[Feature] 유저 정보 수정 API

### DIFF
--- a/src/apps/server/experiences/dto/res/getExperience.res.dto.ts
+++ b/src/apps/server/experiences/dto/res/getExperience.res.dto.ts
@@ -166,6 +166,9 @@ export class GetExperienceByCapabilityResponseDto {
   @Exclude() private readonly _id: number;
   @Exclude() private readonly _title?: string;
   @Exclude() private readonly _situation?: string;
+  @Exclude() private readonly _task?: string;
+  @Exclude() private readonly _action?: string;
+  @Exclude() private readonly _result?: string;
   @Exclude() private readonly _startDate?: string;
   @Exclude() private readonly _endDate?: string;
   @Exclude() private readonly _experienceStatus: ExperienceStatus;
@@ -181,6 +184,9 @@ export class GetExperienceByCapabilityResponseDto {
     this._id = experience.id;
     this._title = experience.title;
     this._situation = experience.situation;
+    this._task = experience.task;
+    this._action = experience.action;
+    this._result = experience.result;
     this._startDate = getFormattedDate(experience.startDate);
     this._endDate = getFormattedDate(experience.endDate);
     this._experienceStatus = experience.experienceStatus;
@@ -217,14 +223,50 @@ export class GetExperienceByCapabilityResponseDto {
 
   @Expose()
   @ApiPropertyOptional({
-    description: '경험 분해 S에 속하는 situation 내용',
-    example: '디자이너가 한 명 나간 고독과 싸움',
+    description: '경험 분해 S에 속하는 situation, 상황 내용',
+    example: '디프만 13기에 들어갔어요',
     type: String,
   })
   @IsString()
   @IsOptional()
   get situation(): string | undefined {
     return this._situation;
+  }
+
+  @Expose()
+  @ApiPropertyOptional({
+    description: '경험 분해 T에 속하는 task, 문제 내용',
+    example: '디자이너가 한 명 나가서 고독과 싸움을 했어요',
+    type: String,
+  })
+  @IsString()
+  @IsOptional()
+  get task(): string | undefined {
+    return this._task;
+  }
+
+  @Expose()
+  @ApiPropertyOptional({
+    description: '경험 분해 A에 속하는 action, 해결 내용',
+    example: '위기를 기회로 오히려 좋다는 마음가짐으로 도전했어요',
+    type: String,
+  })
+  @IsString()
+  @IsOptional()
+  get action(): string | undefined {
+    return this._action;
+  }
+
+  @Expose()
+  @ApiPropertyOptional({
+    description: '경험 분해 R에 속하는 result, 결과 내용',
+    example: 'insight-out이라는 예쁜 서비스가 탄생했어요',
+    type: String,
+  })
+  @IsString()
+  @IsOptional()
+  get result(): string | undefined {
+    return this._result;
   }
 
   @Expose()

--- a/src/apps/server/resumes/controllers/question.controller.ts
+++ b/src/apps/server/resumes/controllers/question.controller.ts
@@ -6,8 +6,17 @@ import { UserJwtToken } from '🔥apps/server/auth/types/jwt-tokwn.type';
 import { User } from '🔥apps/server/common/decorators/request/user.decorator';
 import { Route } from '🔥apps/server/common/decorators/router/route.decorator';
 import { JwtAuthGuard } from '🔥apps/server/common/guards/jwt-auth.guard';
+import {
+  PatchQuestionDescriptionMd,
+  PatchQuestionResponseDescriptionMd,
+  PatchQuestionSummaryMd,
+} from '🔥apps/server/resumes/docs/patch-question.doc';
 import { GetOneQuestionRequestParamDto, GetOneQuestionResponseDto } from '🔥apps/server/resumes/dtos/get-question.dto';
-import { PatchQuestionRequestParamDto, PatchQuestionRequestBodyDto } from '🔥apps/server/resumes/dtos/patch-question-request.dto';
+import {
+  PatchQuestionRequestParamDto,
+  PatchQuestionRequestBodyDto,
+  PatchQuestionResponseDto,
+} from '🔥apps/server/resumes/dtos/patch-question-request.dto';
 import { PostQuestionResponseDto, PostQuestionRequestBodyDto } from '🔥apps/server/resumes/dtos/post-question.dto';
 import { QuestionsService } from '🔥apps/server/resumes/services/question.service';
 
@@ -77,18 +86,20 @@ export class QuestionsController {
     },
     response: {
       code: HttpStatus.OK,
+      type: PatchQuestionResponseDto,
+      description: PatchQuestionResponseDescriptionMd,
     },
-    summary: '자기소개서 문항 수정',
-    description: '자기소개서 문항 제목 및 내용 수정',
+    summary: PatchQuestionSummaryMd,
+    description: PatchQuestionDescriptionMd,
   })
   async updateOneQuestion(
     @Param() patchQuestionRequestParamDto: PatchQuestionRequestParamDto,
     @Body() body: PatchQuestionRequestBodyDto,
     @User() user: UserJwtToken,
-  ): Promise<ResponseEntity<string>> {
-    await this.questionService.updateOneQuestion(body, patchQuestionRequestParamDto.questionId, user.userId);
+  ): Promise<ResponseEntity<PatchQuestionResponseDto>> {
+    const updatedQuestion = await this.questionService.updateOneQuestion(body, patchQuestionRequestParamDto.questionId, user.userId);
 
-    return ResponseEntity.OK_WITH_MESSAGE('Resume question updated');
+    return ResponseEntity.OK_WITH_DATA(updatedQuestion);
   }
 
   @Route({

--- a/src/apps/server/resumes/docs/patch-question.doc.ts
+++ b/src/apps/server/resumes/docs/patch-question.doc.ts
@@ -1,0 +1,30 @@
+export const PatchQuestionResponseDescriptionMd = `
+### ✅ 자기소개서 문항 수정에 성공했습니다.
+문항의 제목과 답안을 받아서 기존 DB에 저장된 값을 업데이트합니다.
+수정 일자를 반환합니다.
+`;
+
+export const PatchQuestionSummaryMd = `
+자기소개서 문항 수정 API (2023.6.6. Updated)
+`;
+
+export const PatchQuestionDescriptionMd = `
+# 자기소개서 문항 수정 API
+
+## Description
+
+자기소개서 제목과 문항을 받아서 DB에 저장된 자기소개서 문항을 업데이트합니다.
+임시저장 및 자동저장의 주기 및 Trigger에 따라서 호출됩니다.
+
+사용자의 마지막 입력을 기준으로 업데이트가 될 수 있고, 포커스를 잃어 onBlur 이벤트가 발생했을 때에도 업데이트가 발생할 수 있습니다.
+또한, 임시저장 버튼을 눌러서도 임시저장이 가능합니다.
+
+- 2023.6.6 반환 값에 updatedAt이 추가됐습니다.
+
+## Picture
+
+<img width="1104" alt="image" src="https://github.com/depromeet/13th-4team-backend/assets/83271772/a6dd76cd-0b2e-4035-9977-9aae59b5a74c">
+
+## Figma
+⛳️ [자기소개서 작성](https://www.figma.com/file/0ZJ1ulwtU8k0KQuroxU9Wc/%EC%9D%B8%EC%82%AC%EC%9D%B4%ED%8A%B8%EC%95%84%EC%9B%83?type=design&node-id=1221-11167&t=nNIhb8U7EAcbAZnX-4)
+`;

--- a/src/apps/server/resumes/dtos/patch-question-request.dto.ts
+++ b/src/apps/server/resumes/dtos/patch-question-request.dto.ts
@@ -1,13 +1,7 @@
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
-import { Type } from 'class-transformer';
-import {
-  IsInt,
-  IsNotEmpty,
-  IsOptional,
-  IsPositive,
-  IsString,
-  MaxLength,
-} from 'class-validator';
+import { Question } from '@prisma/client';
+import { Exclude, Expose, Type } from 'class-transformer';
+import { IsDate, IsInt, IsNotEmpty, IsOptional, IsPositive, IsString, MaxLength } from 'class-validator';
 
 export class PatchQuestionRequestParamDto {
   @ApiProperty({
@@ -39,4 +33,24 @@ export class PatchQuestionRequestBodyDto {
   @IsOptional()
   @MaxLength(2000)
   answer?: string | undefined;
+}
+
+export class PatchQuestionResponseDto {
+  @Exclude() private readonly _updatedAt: Date;
+
+  constructor(question: Question) {
+    this._updatedAt = question.updatedAt;
+  }
+
+  @Expose()
+  @ApiProperty({
+    description: '자기소개서 수정 일자입니다. UTC 날짜를 반환합니다.',
+    example: new Date(),
+    type: Date,
+  })
+  @IsDate()
+  @IsNotEmpty()
+  get updatedAt(): Date {
+    return this._updatedAt;
+  }
 }

--- a/src/apps/server/resumes/services/question.service.ts
+++ b/src/apps/server/resumes/services/question.service.ts
@@ -2,7 +2,7 @@ import { Injectable, NotFoundException } from '@nestjs/common';
 import { QuestionRepository } from '📚libs/modules/database/repositories/question.repository';
 import { ResumeRepository } from '📚libs/modules/database/repositories/resume.repository';
 import { PostQuestionResponseDto } from '../dtos/post-question.dto';
-import { PatchQuestionRequestBodyDto } from '🔥apps/server/resumes/dtos/patch-question-request.dto';
+import { PatchQuestionRequestBodyDto, PatchQuestionResponseDto } from '🔥apps/server/resumes/dtos/patch-question-request.dto';
 import { GetOneQuestionResponseDto } from '🔥apps/server/resumes/dtos/get-question.dto';
 
 @Injectable()
@@ -32,7 +32,7 @@ export class QuestionsService {
     return questionReponseDto;
   }
 
-  async updateOneQuestion(body: PatchQuestionRequestBodyDto, questionId: number, userId: number): Promise<void> {
+  async updateOneQuestion(body: PatchQuestionRequestBodyDto, questionId: number, userId: number): Promise<PatchQuestionResponseDto> {
     const { title, answer } = body;
 
     const question = await this.questionRepository.findFirst({
@@ -44,10 +44,13 @@ export class QuestionsService {
     }
 
     if (title || answer) {
-      await this.questionRepository.update({
-        data: { title, answer },
-        where: { id: questionId },
-      });
+      return new PatchQuestionResponseDto(
+        await this.questionRepository.update({
+          data: { title, answer },
+          where: { id: questionId },
+          select: { updatedAt: true },
+        }),
+      );
     }
   }
 

--- a/src/apps/server/users/docs/patch-user-info.doc.ts
+++ b/src/apps/server/users/docs/patch-user-info.doc.ts
@@ -1,0 +1,27 @@
+export const PatchUserInfoResponseDescriptionMd = `
+### ✅ 유저 정보 업데이트에 성공했습니다.
+닉네임 혹은 직무가 업데이트 됐습니다.
+`;
+
+export const PatchUserInfoSummaryMd = `
+유저 정보 업데이트 API
+`;
+
+export const PatchUserInfoDescriptionMd = `
+# 유저 정보 업데이트 API
+
+## Description
+
+유저 정보를 업데이트합니다. 이미지 업로드는 MVP가 아니며, 구글 계정은 유저가 임의로 바꿀 수 없습니다.
+
+닉네임과 직무만 변경 가능합니다. 단순 변경이므로 반환값은 없습니다.
+성공 시 Update success라는 문자열을 반환합니다.
+
+## Picture
+
+<img width="429" alt="image" src="https://github.com/depromeet/13th-4team-backend/assets/83271772/f0fe0074-c626-42dc-a2d4-36488c3f66d9">
+
+## Figma
+
+⛳️ [마이페이지 직무 변경시](https://www.figma.com/file/0ZJ1ulwtU8k0KQuroxU9Wc/%EC%9D%B8%EC%82%AC%EC%9D%B4%ED%8A%B8%EC%95%84%EC%9B%83?type=design&node-id=1418-10717&t=lyE6efKKKmrSS2Vf-4)
+`;

--- a/src/apps/server/users/dtos/patch-user-info.dto.ts
+++ b/src/apps/server/users/dtos/patch-user-info.dto.ts
@@ -1,0 +1,27 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { Field } from '@prisma/client';
+import { IsEnum, IsNotEmpty, IsOptional, IsString } from 'class-validator';
+
+export class PatchUserInfoRequestBodyDto {
+  @ApiProperty({
+    description: '유저 닉네임',
+    example: '저뉴진스하입보이요',
+    type: String,
+  })
+  @IsString()
+  @IsOptional()
+  @IsNotEmpty()
+  nickname?: string | undefined;
+
+  @ApiProperty({
+    description: '유저의 직무',
+    enum: Field,
+    type: Field,
+    example: Field.DEVELOPMENT,
+  })
+  @IsEnum(Field)
+  @IsString()
+  @IsOptional()
+  @IsNotEmpty()
+  field?: Field | undefined;
+}

--- a/src/apps/server/users/user.controller.ts
+++ b/src/apps/server/users/user.controller.ts
@@ -6,6 +6,11 @@ import { UserJwtToken } from '🔥apps/server/auth/types/jwt-tokwn.type';
 import { User } from '🔥apps/server/common/decorators/request/user.decorator';
 import { Route } from '🔥apps/server/common/decorators/router/route.decorator';
 import { JwtAuthGuard } from '🔥apps/server/common/guards/jwt-auth.guard';
+import {
+  PatchUserInfoDescriptionMd,
+  PatchUserInfoResponseDescriptionMd,
+  PatchUserInfoSummaryMd,
+} from '🔥apps/server/users/docs/patch-user-info.doc';
 import { PatchUserInfoRequestBodyDto } from '🔥apps/server/users/dtos/patch-user-info.dto';
 import { PostSendFeedbackRequestBodyDto } from '🔥apps/server/users/dtos/post-feedback.dto';
 import { UserService } from '🔥apps/server/users/user.service';
@@ -51,7 +56,10 @@ export class UserController {
     },
     response: {
       code: HttpStatus.OK,
+      description: PatchUserInfoResponseDescriptionMd,
     },
+    summary: PatchUserInfoSummaryMd,
+    description: PatchUserInfoDescriptionMd,
   })
   async updateUserInfo(
     @User() user: UserJwtToken,

--- a/src/apps/server/users/user.controller.ts
+++ b/src/apps/server/users/user.controller.ts
@@ -1,8 +1,12 @@
-import { Body, Controller, HttpStatus } from '@nestjs/common';
+import { Body, Controller, HttpStatus, UseGuards } from '@nestjs/common';
 import { ApiTags } from '@nestjs/swagger';
 import { Method } from '📚libs/enums/method.enum';
 import { ResponseEntity } from '📚libs/utils/respone.entity';
+import { UserJwtToken } from '🔥apps/server/auth/types/jwt-tokwn.type';
+import { User } from '🔥apps/server/common/decorators/request/user.decorator';
 import { Route } from '🔥apps/server/common/decorators/router/route.decorator';
+import { JwtAuthGuard } from '🔥apps/server/common/guards/jwt-auth.guard';
+import { PatchUserInfoRequestBodyDto } from '🔥apps/server/users/dtos/patch-user-info.dto';
 import { PostSendFeedbackRequestBodyDto } from '🔥apps/server/users/dtos/post-feedback.dto';
 import { UserService } from '🔥apps/server/users/user.service';
 
@@ -37,5 +41,24 @@ export class UserController {
     await this.userService.sendFeedback(postSendFeedbackRequestBodyDto);
 
     return ResponseEntity.CREATED_WITH_MESSAGE('Feedback has been sent');
+  }
+
+  @UseGuards(JwtAuthGuard)
+  @Route({
+    request: {
+      path: '',
+      method: Method.PATCH,
+    },
+    response: {
+      code: HttpStatus.OK,
+    },
+  })
+  async updateUserInfo(
+    @User() user: UserJwtToken,
+    @Body() patchUserInfoRequestBodyDto: PatchUserInfoRequestBodyDto,
+  ): Promise<ResponseEntity<string>> {
+    await this.userService.updateUserInfo(user.userId, patchUserInfoRequestBodyDto);
+
+    return ResponseEntity.OK_WITH_MESSAGE('Update success');
   }
 }

--- a/src/apps/server/users/user.service.ts
+++ b/src/apps/server/users/user.service.ts
@@ -1,6 +1,7 @@
-import { Injectable } from '@nestjs/common';
+import { BadRequestException, Injectable } from '@nestjs/common';
 import { FeedbackRepository } from '📚libs/modules/database/repositories/feedback.repository';
 import { UserRepository } from '📚libs/modules/database/repositories/user.repository';
+import { PatchUserInfoRequestBodyDto } from '🔥apps/server/users/dtos/patch-user-info.dto';
 import { PostSendFeedbackRequestBodyDto } from '🔥apps/server/users/dtos/post-feedback.dto';
 
 @Injectable()
@@ -16,6 +17,17 @@ export class UserService {
     const { contents } = body;
     await this.feedbackRepository.create({
       data: { contents },
+    });
+  }
+
+  async updateUserInfo(userId: number, body: PatchUserInfoRequestBodyDto): Promise<void> {
+    if (!Object.keys(body).length) {
+      throw new BadRequestException('Please input information to be updated');
+    }
+
+    await this.userRepository.update({
+      data: { nickname: body.nickname, UserInfo: { update: { field: body.field } } },
+      where: { id: userId },
     });
   }
 }

--- a/src/libs/modules/database/schema.prisma
+++ b/src/libs/modules/database/schema.prisma
@@ -23,7 +23,7 @@ model User {
   createdAt DateTime  @default(now()) @map("created_at") @db.Timestamptz
   updatedAt DateTime  @updatedAt @map("updated_at") @db.Timestamptz
   deletedAt DateTime? @map("deleted_at") @db.Timestamptz
-  nickname  String    @db.VarChar(6)
+  nickname  String    @db.VarChar(10)
 
   UserInfo    UserInfo?
   Onboarding  Onboarding?
@@ -87,10 +87,10 @@ model UserInfo {
 model Onboarding {
   userId Int @id
 
-  experience Boolean @default(false) // 경험분해 온보딩 여부
+  experience        Boolean @default(false) // 경험분해 온보딩 여부
   experienceStepper Boolean @default(false) @map("experience_stepper") // 경험분해 stepper 온보딩 여부
-  resume Boolean @default(false) // 자기소개서 작성 온보딩 여부
-  collection Boolean @default(false) // 모아보기 온보딩 여부
+  resume            Boolean @default(false) // 자기소개서 작성 온보딩 여부
+  collection        Boolean @default(false) // 모아보기 온보딩 여부
 
   User User @relation(references: [id], fields: [userId])
 
@@ -104,7 +104,7 @@ model Onboarding {
 // 자기소개서 제목
 model Resume {
   id    Int    @id @default(autoincrement())
-  title String @db.VarChar(13) @default("새 자기소개서") // 자기소개서 제목
+  title String @default("새 자기소개서") @db.VarChar(13) // 자기소개서 제목
 
   createdAt DateTime @default(now()) @map("created_at") @db.Timestamptz
   updatedAt DateTime @updatedAt @map("updated_at") @db.Timestamptz
@@ -124,7 +124,7 @@ model Question {
   id       Int @id @default(autoincrement())
   resumeId Int @map("resume_id") // 자기소개서 제목 pfk
 
-  title  String?  @db.VarChar(300) // 문항 제목
+  title  String? @db.VarChar(300) // 문항 제목
   answer String? @db.VarChar(2500) // 문항 내용
 
   createdAt DateTime @default(now()) @map("created_at") @db.Timestamptz
@@ -224,7 +224,7 @@ model Capability {
 }
 
 model ExperienceCapability {
-  experienceId  Int @map("experience_id")
+  experienceId Int @map("experience_id")
   capabilityId Int @map("capability_id")
 
   Experience Experience @relation(references: [id], fields: [experienceId])


### PR DESCRIPTION
## ⛳️ 기능 구현 배경

---

<!-- 기능 구현 배경에 대해 작성해주세요 -->

마이페이지에서 유저 정보가 수정 가능하므로, 해당 기능을 구현했습니다.

## 😤 기능 구현 내용(Optional)

---

<!-- 기능 구현 내용에 대해 적어주세요 -->

```ts
  async updateUserInfo(userId: number, body: PatchUserInfoRequestBodyDto): Promise<void> {
    if (!Object.keys(body).length) {
      throw new BadRequestException('Please input information to be updated');
    }

    await this.userRepository.update({
      data: { nickname: body.nickname, UserInfo: { update: { field: body.field } } },
      where: { id: userId },
    });
  }
```

유저 정보 중 image는 현 MVP가 아니고, 구글 계정은 유저가 임의로 바꿀 수 없으므로,
nickname과 field(직무 분야)만 바꿀 수 있습니다.

## 📭 이슈 번호

---

<!-- 이슈 번호를 남겨주세요 -->

#132 

## 🧐 의견 구하기

---

<!-- 구하고 싶은 의견이 있다면 작성해주세요 -->

## 🙏 P.S

---

<!-- 추가적으로 남기고 싶은 말을 적어주세요 -->
