### PR TITLE
[Feature] 경험분해 API에서 query string 추가하여 s, t, a, r 조회 

### DIFF
--- a/src/apps/server/common/consts/experience-attribute.const.ts
+++ b/src/apps/server/common/consts/experience-attribute.const.ts
@@ -6,10 +6,10 @@ export const getExperienceAttribute: ExperienceSelect = {
   startDate: true,
   endDate: true,
   experienceStatus: true,
-  situation: true,
-  task: true,
-  action: true,
-  result: true,
+  // situation: true,
+  // task: true,
+  // action: true,
+  // result: true,
   ExperienceInfo: {
     select: {
       experienceId: true,

--- a/src/apps/server/experiences/controllers/experience.controller.ts
+++ b/src/apps/server/experiences/controllers/experience.controller.ts
@@ -89,10 +89,10 @@ export class ExperienceController {
     let experience;
 
     if (getExperienceRequestQueryDto.capabilityId) {
-      experience = await this.experienceService.getExperienceByCapability(getExperienceRequestQueryDto.capabilityId);
+      experience = await this.experienceService.getExperienceByCapability(getExperienceRequestQueryDto);
     } else {
       // TODO 추후 전체 모아보기를 위해 수정 필요
-      experience = await this.experienceService.getExperiencesByUserId(user.userId);
+      experience = await this.experienceService.getExperiencesByUserId(user.userId, getExperienceRequestQueryDto);
     }
 
     if (getExperienceRequestQueryDto.last) {

--- a/src/apps/server/experiences/dto/req/get-experience.dto.ts
+++ b/src/apps/server/experiences/dto/req/get-experience.dto.ts
@@ -23,4 +23,60 @@ export class GetExperienceRequestQueryDto {
     return _.obj.last === 'true' ? true : false;
   })
   last?: boolean;
+
+  @ApiPropertyOptional({
+    description:
+      '경험 카드에서 situation을 가져올지에 대한 filter query입니다. true를 입력하면, 응답에 situation이 추가되고 입력하지 않거나 false를 입력하면, 응답에 situation이 제외됩니다.',
+    example: true,
+    type: Boolean,
+  })
+  @IsOptional()
+  @IsBoolean()
+  @IsNotEmpty()
+  @Transform((_) => {
+    return _.obj.situation === 'true' ? true : false;
+  })
+  situation?: boolean;
+
+  @ApiPropertyOptional({
+    description:
+      '경험 카드에서 task를 가져올지에 대한 filter query입니다. true를 입력하면, 응답에 task가 추가되고 입력하지 않거나 false를 입력하면, 응답에 task가 제외됩니다.',
+    example: true,
+    type: Boolean,
+  })
+  @IsOptional()
+  @IsBoolean()
+  @IsNotEmpty()
+  @Transform((_) => {
+    return _.obj.task === 'true' ? true : false;
+  })
+  task?: boolean;
+
+  @ApiPropertyOptional({
+    description:
+      '경험 카드에서 action을 가져올지에 대한 filter query입니다. true를 입력하면, 응답에 action이 추가되고 입력하지 않거나 false를 입력하면, 응답에 action이 제외됩니다.',
+    example: true,
+    type: Boolean,
+  })
+  @IsOptional()
+  @IsBoolean()
+  @IsNotEmpty()
+  @Transform((_) => {
+    return _.obj.action === 'true' ? true : false;
+  })
+  action?: boolean;
+
+  @ApiPropertyOptional({
+    description:
+      '경험 카드에서 result를 가져올지에 대한 filter query입니다. true를 입력하면, 응답에 result가 추가되고 입력하지 않거나 false를 입력하면, 응답에 result가 제외됩니다.',
+    example: true,
+    type: Boolean,
+  })
+  @IsOptional()
+  @IsBoolean()
+  @IsNotEmpty()
+  @Transform((_) => {
+    return _.obj.result === 'true' ? true : false;
+  })
+  result?: boolean;
 }

--- a/src/apps/server/experiences/dto/res/getExperience.res.dto.ts
+++ b/src/apps/server/experiences/dto/res/getExperience.res.dto.ts
@@ -177,7 +177,7 @@ export class GetExperienceByCapabilityResponseDto {
   @Exclude() private readonly _experienceSummary: ExperienceSummary[];
 
   constructor(
-    experience: Experience & {
+    experience: Partial<Experience> & {
       capability: Omit<Capability, 'userId'>[];
     },
   ) {

--- a/src/apps/server/experiences/markdown/experience.md.ts
+++ b/src/apps/server/experiences/markdown/experience.md.ts
@@ -1,5 +1,15 @@
 export const getExperienceSuccMd = `
 ### ✅ 경험 분해 조회에 성공했습니다.
+s, t, a, r의 경험 카드 내용을 조회하기 위해서 각각 querystring에 boolean 값을 입력합니다.\n
+예를 들어서,
+- situation=true를 입력하면, situation 정보만 가져옵니다.
+- situation=true&task=true를 입력하면, situation, task 정보만 가져옵니다.\n
+
+추가적으로, 마지막으로 만든 경험카드 한 개만을 조회하기 위해서는 querystring에서 last라는 키에 대해 값을 boolean으로 넣어주세요.\n
+예를 들어서 last=true를 입력했을 때, 유저가 마지막으로 만든 경험카드 한 개만을 조회합니다.
+
+---
+
 유저가 생성 중인 경험 분해가 있다면 \`생성 중인 경험분해\`를 반환합니다.\n
  처음 경험 분해를 생성하는 것이면 \`INPROGRESS 상태의 경험카드가 없습니다\`라는 문구가 나옵니다.
 `;

--- a/src/apps/server/experiences/services/experience.service.ts
+++ b/src/apps/server/experiences/services/experience.service.ts
@@ -13,6 +13,7 @@ import {
 } from '🔥apps/server/experiences/dto/get-count-of-experience-and-capability.dto';
 import { CapabilityRepository } from '📚libs/modules/database/repositories/capability.repository';
 import { CountExperienceAndCapability } from '🔥apps/server/experiences/types/count-experience-and-capability.type';
+import { GetExperienceRequestQueryDto } from '🔥apps/server/experiences/dto/req/get-experience.dto';
 
 @Injectable()
 export class ExperienceService {
@@ -51,8 +52,9 @@ export class ExperienceService {
     }
   }
 
-  public async getExperienceByCapability(capabilityId: number): Promise<GetExperienceByCapabilityResponseDto[]> {
-    const experience = await this.experienceRepository.getExperienceByCapability(capabilityId);
+  public async getExperienceByCapability(query: GetExperienceRequestQueryDto): Promise<GetExperienceByCapabilityResponseDto[]> {
+    const { capabilityId, last, ...select } = query;
+    const experience = await this.experienceRepository.getExperienceByCapability(capabilityId, select);
     if (!experience.length) {
       throw new NotFoundException('Experience not found');
     }
@@ -74,9 +76,10 @@ export class ExperienceService {
     }
   }
 
-  public async getExperiencesByUserId(userId: number): Promise<GetExperienceResDto[] | string> {
+  public async getExperiencesByUserId(userId: number, query: GetExperienceRequestQueryDto): Promise<GetExperienceResDto[] | string> {
     try {
-      const experience = await this.experienceRepository.findManyByUserId(userId, getExperienceAttribute);
+      const { capabilityId, last, ...select } = query;
+      const experience = await this.experienceRepository.findManyByUserId(userId, Object.assign(getExperienceAttribute, select));
       if (!experience.length) return 'INPROGRESS 상태의 경험카드가 없습니다';
 
       return experience.map((experience) => new GetExperienceResDto(experience));

--- a/src/apps/server/resumes/controllers/resumes.controller.ts
+++ b/src/apps/server/resumes/controllers/resumes.controller.ts
@@ -1,4 +1,4 @@
-import { UseGuards, Controller, Query, HttpStatus, Body, Param, ParseIntPipe } from '@nestjs/common';
+import { UseGuards, Controller, Query, HttpStatus, Body, Param } from '@nestjs/common';
 import { ApiTags, ApiQuery, ApiParam } from '@nestjs/swagger';
 import { SuccessResponse } from '📚libs/decorators/success-response.dto';
 

--- a/src/libs/modules/database/repositories/experience.repository.ts
+++ b/src/libs/modules/database/repositories/experience.repository.ts
@@ -48,13 +48,11 @@ export class ExperienceRepository implements ExperienceRepositoryInterface {
     });
   }
 
-  public async getExperienceByCapability(capabilityId: number) {
+  public async getExperienceByCapability(capabilityId: number, select: Partial<ExperienceSelect>) {
     // TODO ai 역량 키워드가 적용되면 해당 키워드도 함께 쿼리로 가져와야 함.
     const experiences = await this.prisma.experience.findMany({
       where: { ExperienceCapability: { some: { capabilityId: { equals: capabilityId } } } },
-      include: {
-        ExperienceCapability: true,
-      },
+      select: { id: true, title: true, startDate: true, endDate: true, ...select },
       orderBy: { createdAt: 'desc' },
     });
 
@@ -65,9 +63,7 @@ export class ExperienceRepository implements ExperienceRepositoryInterface {
           select: { id: true, keyword: true },
         });
 
-        const { ExperienceCapability, ...rest } = experience;
-
-        return Object.assign(rest, { capability });
+        return Object.assign(experience, { capability });
       }),
     );
 


### PR DESCRIPTION
## ⛳️ 기능 구현 배경

---

<!-- 기능 구현 배경에 대해 작성해주세요 -->

경험카드를 조회할 때 s, t, a, r에 대한 쿼리를 추가하여 각각을 개별적으로 가져옵니다.

GET /experience 를 사용하는 페이지가 많기 때문에 한 번 통제하고 RESTful 하게 API를 구현하고자 합니다.

## 😤 기능 구현 내용(Optional)

---

<!-- 기능 구현 내용에 대해 적어주세요 -->

situation, task, action, result 각각에 쿼리 요청을 보내서 원하는 값만 응답에 넣을 수 있도록 합니다.

모아보기에서는 situation을 사용하며, 경험 분해 페이지에서는 situation, task, action, result를 모두 사용하고, 자기소개서 페이지에서 경험 카드를 조회할 때는 사용하지 않습니다.

## 📭 이슈 번호

---

<!-- 이슈 번호를 남겨주세요 -->

#143 

## 🧐 의견 구하기

---

<!-- 구하고 싶은 의견이 있다면 작성해주세요 -->

## 🙏 P.S

---

<!-- 추가적으로 남기고 싶은 말을 적어주세요 -->
