### PR TITLE
[Feature] 경험카드의 star 조회 API 추가

### DIFF
--- a/src/apps/server/experiences/controllers/experience.controller.ts
+++ b/src/apps/server/experiences/controllers/experience.controller.ts
@@ -1,4 +1,4 @@
-import { Body, HttpStatus, Query, UseGuards } from '@nestjs/common';
+import { Body, HttpStatus, Param, Query, UseGuards } from '@nestjs/common';
 import { Route } from '../../common/decorators/router/route.decorator';
 import { RouteTable } from '../../common/decorators/router/route-table.decorator';
 import { UpsertExperienceReqDto } from '../dto/req/upsertExperience.dto';
@@ -31,6 +31,10 @@ import {
   GetCountOfExperienceResponseDescriptionMd,
   GetCountOfExperienceSummaryMd,
 } from '🔥apps/server/experiences/markdown/get-count-of-experience.md';
+import {
+  GetStarFromExperienceRequestParamDto,
+  GetStarFromExperienceResponseDto,
+} from '🔥apps/server/experiences/dto/get-star-from-experience.dto';
 
 @ApiBearerAuth()
 @UseGuards(JwtAuthGuard)
@@ -116,7 +120,7 @@ export class ExperienceController {
     summary: GetCountOfExperienceAndCapabilitySummaryMd,
     description: GetCountOfExperienceAndCapabilityDescriptionMd,
   })
-  async getCountOfExperienceAndCapability(
+  public async getCountOfExperienceAndCapability(
     @User() user: UserJwtToken,
   ): Promise<ResponseEntity<GetCountOfExperienceAndCapabilityResponseDto[]>> {
     const countOfExperienceAndCapability = await this.experienceService.getCountOfExperienceAndCapability(user.userId);
@@ -137,9 +141,28 @@ export class ExperienceController {
     summary: GetCountOfExperienceSummaryMd,
     description: GetCountOfExperienceDescriptionMd,
   })
-  async getCountOfExperience(@User() user: UserJwtToken): Promise<ResponseEntity<GetCountOfExperienceResponseDto>> {
+  public async getCountOfExperience(@User() user: UserJwtToken): Promise<ResponseEntity<GetCountOfExperienceResponseDto>> {
     const countOfExperience = await this.experienceService.getCountOfExperience(user.userId);
 
     return ResponseEntity.OK_WITH_DATA(countOfExperience);
+  }
+
+  // ✅ 경험카드 star 조회
+  @Route({
+    request: {
+      path: '/star/:experienceId',
+      method: Method.GET,
+    },
+    response: {
+      code: HttpStatus.OK,
+      type: GetStarFromExperienceResponseDto,
+    },
+  })
+  public async getStarFromExperienceByExperienceId(
+    @Param() getStarFromExperienceRequestParamDto: GetStarFromExperienceRequestParamDto,
+  ): Promise<ResponseEntity<GetStarFromExperienceResponseDto>> {
+    const star = await this.experienceService.getStarFromExperienceByExperienceId(getStarFromExperienceRequestParamDto.experienceId);
+
+    return ResponseEntity.OK_WITH_DATA(star);
   }
 }

--- a/src/apps/server/experiences/controllers/experience.controller.ts
+++ b/src/apps/server/experiences/controllers/experience.controller.ts
@@ -35,6 +35,11 @@ import {
   GetStarFromExperienceRequestParamDto,
   GetStarFromExperienceResponseDto,
 } from '🔥apps/server/experiences/dto/get-star-from-experience.dto';
+import {
+  GetStarFromExperienceDescriptionMd,
+  GetStarFromExperienceResponseDescriptionMd,
+  GetStarFromExperienceSummaryMd,
+} from '🔥apps/server/experiences/markdown/get-star-from-experience.md';
 
 @ApiBearerAuth()
 @UseGuards(JwtAuthGuard)
@@ -156,7 +161,10 @@ export class ExperienceController {
     response: {
       code: HttpStatus.OK,
       type: GetStarFromExperienceResponseDto,
+      description: GetStarFromExperienceResponseDescriptionMd,
     },
+    summary: GetStarFromExperienceSummaryMd,
+    description: GetStarFromExperienceDescriptionMd,
   })
   public async getStarFromExperienceByExperienceId(
     @Param() getStarFromExperienceRequestParamDto: GetStarFromExperienceRequestParamDto,

--- a/src/apps/server/experiences/dto/get-star-from-experience.dto.ts
+++ b/src/apps/server/experiences/dto/get-star-from-experience.dto.ts
@@ -1,0 +1,17 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { Experience } from '@prisma/client';
+import { Exclude, Expose, Type } from 'class-transformer';
+import { IsInt, IsNotEmpty, IsPositive, IsString, MaxLength, MinLength } from 'class-validator';
+
+export class GetStarFromExperienceRequestParamDto {
+  @ApiProperty({
+    description: '경험 카드 id입니다.',
+    example: 1234,
+    type: Number,
+  })
+  @IsInt()
+  @IsPositive()
+  @IsNotEmpty()
+  @Type(() => Number)
+  experienceId: number;
+}

--- a/src/apps/server/experiences/dto/get-star-from-experience.dto.ts
+++ b/src/apps/server/experiences/dto/get-star-from-experience.dto.ts
@@ -17,12 +17,16 @@ export class GetStarFromExperienceRequestParamDto {
 }
 
 export class GetStarFromExperienceResponseDto {
+  @Exclude() private readonly _id: number;
+  @Exclude() private readonly _title: string;
   @Exclude() private readonly _situation: string;
   @Exclude() private readonly _task: string;
   @Exclude() private readonly _action: string;
   @Exclude() private readonly _result: string;
 
-  constructor(experience: Pick<Experience, 'situation' | 'task' | 'action' | 'result'>) {
+  constructor(experience: Pick<Experience, 'id' | 'title' | 'situation' | 'task' | 'action' | 'result'>) {
+    this._id = experience.id;
+    this._title = experience.title;
     this._situation = experience.situation;
     this._task = experience.task;
     this._action = experience.action;
@@ -31,7 +35,34 @@ export class GetStarFromExperienceResponseDto {
 
   @Expose()
   @ApiProperty({
-    description: 'STAR의 S: situation으로, 경험카드에서 활동의 계기나 배경으로 적은 내용입니다.',
+    description: '경험카드의 id입니다.',
+    example: 1234,
+    type: Number,
+  })
+  @IsInt()
+  @IsPositive()
+  @IsNotEmpty()
+  get id(): number {
+    return this._id;
+  }
+
+  @Expose()
+  @ApiProperty({
+    description: '경험 카드의 제목입니다.',
+    example: '디프만 12기 백엔드 파트장',
+    type: String,
+  })
+  @IsString()
+  @MinLength(1)
+  @MaxLength(50)
+  @IsNotEmpty()
+  get title(): string {
+    return this._title;
+  }
+
+  @Expose()
+  @ApiProperty({
+    description: 'STAR의 S: situation으로, 경험카드에서 활동의 계기나 배경으로 적은 내용입니다. 최대 100자입니다.',
     example: '코딩에 관심이 생겼고, 디자이너와 협업이 하고 싶었음',
     type: String,
   })
@@ -45,7 +76,7 @@ export class GetStarFromExperienceResponseDto {
 
   @Expose()
   @ApiProperty({
-    description: 'STAR의 T: task로, 경험카드에서 당시 해결해야 하는 과제나 목표로 적은 내용입니다.',
+    description: 'STAR의 T: task로, 경험카드에서 당시 해결해야 하는 과제나 목표로 적은 내용입니다. 최대 100자입니다.',
     example: '백엔드 파트장으로서 팀을 이끌어야 했고, 소셜 로그인 API를 모두 구현해야 했음',
     type: String,
   })
@@ -58,7 +89,7 @@ export class GetStarFromExperienceResponseDto {
   }
   @Expose()
   @ApiProperty({
-    description: 'STAR의 A: action으로, 경험카드에서 내가 취한 행동 또는 계획으로 적은 내용입니다.',
+    description: 'STAR의 A: action으로, 경험카드에서 내가 취한 행동 또는 계획으로 적은 내용입니다. 최대 100자입니다.',
     example: '모든 API 명세를 읽어보았고, 어떻게 소셜 로그인 제공자 서버와 통신하는지 공부함',
     type: String,
   })
@@ -71,7 +102,8 @@ export class GetStarFromExperienceResponseDto {
   }
   @Expose()
   @ApiProperty({
-    description: 'STAR의 R: result로, 경험카드에서 어떤 성과(객관적 사실, 정량적 수치)를 이룰 수 있었는지에 관해 적은 내용입니다.',
+    description:
+      'STAR의 R: result로, 경험카드에서 어떤 성과(객관적 사실, 정량적 수치)를 이룰 수 있었는지에 관해 적은 내용입니다. 최대 100자입니다.',
     example: '미친 성장을 할 수 있었다.',
     type: String,
   })

--- a/src/apps/server/experiences/dto/get-star-from-experience.dto.ts
+++ b/src/apps/server/experiences/dto/get-star-from-experience.dto.ts
@@ -15,3 +15,71 @@ export class GetStarFromExperienceRequestParamDto {
   @Type(() => Number)
   experienceId: number;
 }
+
+export class GetStarFromExperienceResponseDto {
+  @Exclude() private readonly _situation: string;
+  @Exclude() private readonly _task: string;
+  @Exclude() private readonly _action: string;
+  @Exclude() private readonly _result: string;
+
+  constructor(experience: Pick<Experience, 'situation' | 'task' | 'action' | 'result'>) {
+    this._situation = experience.situation;
+    this._task = experience.task;
+    this._action = experience.action;
+    this._result = experience.result;
+  }
+
+  @Expose()
+  @ApiProperty({
+    description: 'STAR의 S: situation으로, 경험카드에서 활동의 계기나 배경으로 적은 내용입니다.',
+    example: '코딩에 관심이 생겼고, 디자이너와 협업이 하고 싶었음',
+    type: String,
+  })
+  @IsString()
+  @MinLength(1)
+  @MaxLength(100)
+  @IsNotEmpty()
+  get situation(): string {
+    return this._situation;
+  }
+
+  @Expose()
+  @ApiProperty({
+    description: 'STAR의 T: task로, 경험카드에서 당시 해결해야 하는 과제나 목표로 적은 내용입니다.',
+    example: '백엔드 파트장으로서 팀을 이끌어야 했고, 소셜 로그인 API를 모두 구현해야 했음',
+    type: String,
+  })
+  @IsString()
+  @MinLength(1)
+  @MaxLength(100)
+  @IsNotEmpty()
+  get task(): string {
+    return this._task;
+  }
+  @Expose()
+  @ApiProperty({
+    description: 'STAR의 A: action으로, 경험카드에서 내가 취한 행동 또는 계획으로 적은 내용입니다.',
+    example: '모든 API 명세를 읽어보았고, 어떻게 소셜 로그인 제공자 서버와 통신하는지 공부함',
+    type: String,
+  })
+  @IsString()
+  @MinLength(1)
+  @MaxLength(100)
+  @IsNotEmpty()
+  get action(): string {
+    return this._action;
+  }
+  @Expose()
+  @ApiProperty({
+    description: 'STAR의 R: result로, 경험카드에서 어떤 성과(객관적 사실, 정량적 수치)를 이룰 수 있었는지에 관해 적은 내용입니다.',
+    example: '미친 성장을 할 수 있었다.',
+    type: String,
+  })
+  @IsString()
+  @MinLength(1)
+  @MaxLength(100)
+  @IsNotEmpty()
+  get result(): string {
+    return this._result;
+  }
+}

--- a/src/apps/server/experiences/markdown/get-star-from-experience.md.ts
+++ b/src/apps/server/experiences/markdown/get-star-from-experience.md.ts
@@ -1,0 +1,32 @@
+export const GetStarFromExperienceResponseDescriptionMd = `
+### ✅ 경험카드 S, T, A, R 조회에 성공했습니다.
+
+자기소개서 작성 페이지에서 경험 카드를 눌렀을 때, 오른쪽 분할 화면에 출력될 S, T, A, R 데이터입니다.
+`;
+
+export const GetStarFromExperienceSummaryMd = `
+경험카드 S, T, A, R 조회 API
+`;
+
+export const GetStarFromExperienceDescriptionMd = `
+# 경험카드 S, T, A, R 조회 API
+
+## Description
+
+경험카드의 S, T, A, R을 조회합니다.\n
+
+S, T, A, R은 각각 **100자**로 총 **400자**의 페이로드를 가집니다.\n
+
+해당 API가 사용되는 위치는 **자기소개서 작성 페이지**에서의 경험 카드에 대한 컴포넌트입니다.\n
+request URI에서 **experienceId**를 path parameter로 입력해주세요.\n
+
+서버에서는 path parameter에 있는 **experienceId**를 통해서 DB에 있는 경험 카드의 **S**, **T**, **A**, **R**을 가져옵니다.\n
+
+## Picture
+
+<img width="568" alt="image" src="https://github.com/depromeet/InsightOut-Server/assets/83271772/5482f97f-2257-4d2a-8537-a1be7dd95a58">
+
+## Figma
+
+⛳️ [자기소개서 작성 첫화면](https://www.figma.com/file/0ZJ1ulwtU8k0KQuroxU9Wc/%EC%9D%B8%EC%82%AC%EC%9D%B4%ED%8A%B8%EC%95%84%EC%9B%83?type=design&node-id=1221-8169&t=40PA9IdsKSnKAGBa-4)
+`;

--- a/src/apps/server/experiences/services/experience.service.ts
+++ b/src/apps/server/experiences/services/experience.service.ts
@@ -14,6 +14,7 @@ import {
 import { CapabilityRepository } from '📚libs/modules/database/repositories/capability.repository';
 import { CountExperienceAndCapability } from '🔥apps/server/experiences/types/count-experience-and-capability.type';
 import { GetExperienceRequestQueryDto } from '🔥apps/server/experiences/dto/req/get-experience.dto';
+import { GetStarFromExperienceResponseDto } from '🔥apps/server/experiences/dto/get-star-from-experience.dto';
 
 @Injectable()
 export class ExperienceService {
@@ -180,5 +181,18 @@ export class ExperienceService {
     const getCountOfExperienceResponseDto = new GetCountOfExperienceResponseDto(countOfExperience);
 
     return getCountOfExperienceResponseDto;
+  }
+
+  // ✅ 경험카드 star 조회
+  public async getStarFromExperienceByExperienceId(experienceId: number): Promise<GetStarFromExperienceResponseDto> {
+    const star = await this.experienceRepository.getStarFromExperienceByExperienceId(experienceId);
+
+    // 만약 situation, task, action, result 중에서 하나라도 누락됐다면
+    if (!(star.situation && star.task && star.action && star.result)) {
+      throw new NotFoundException('There are missing info about S, T, A, R');
+    }
+
+    const getStarFromExperienceResponseDto = new GetStarFromExperienceResponseDto(star);
+    return getStarFromExperienceResponseDto;
   }
 }

--- a/src/libs/modules/database/repositories/experience.repository.ts
+++ b/src/libs/modules/database/repositories/experience.repository.ts
@@ -71,11 +71,12 @@ export class ExperienceRepository implements ExperienceRepositoryInterface {
   }
 
   public async getStarFromExperienceByExperienceId(experienceId: number) {
-    return await this.prisma.experience.findUnique({
+    return await this.prisma.experience.findFirst({
       where: {
         id: experienceId,
+        experienceStatus: ExperienceStatus.DONE,
       },
-      select: { situation: true, task: true, action: true, result: true },
+      select: { id: true, title: true, situation: true, task: true, action: true, result: true },
     });
   }
 }

--- a/src/libs/modules/database/repositories/experience.repository.ts
+++ b/src/libs/modules/database/repositories/experience.repository.ts
@@ -52,7 +52,7 @@ export class ExperienceRepository implements ExperienceRepositoryInterface {
     // TODO ai 역량 키워드가 적용되면 해당 키워드도 함께 쿼리로 가져와야 함.
     const experiences = await this.prisma.experience.findMany({
       where: { ExperienceCapability: { some: { capabilityId: { equals: capabilityId } } } },
-      select: { id: true, title: true, startDate: true, endDate: true, ...select },
+      select: { id: true, title: true, startDate: true, endDate: true, experienceStatus: true, ...select },
       orderBy: { createdAt: 'desc' },
     });
 

--- a/src/libs/modules/database/repositories/experience.repository.ts
+++ b/src/libs/modules/database/repositories/experience.repository.ts
@@ -69,4 +69,13 @@ export class ExperienceRepository implements ExperienceRepositoryInterface {
 
     return experienceWithCapability;
   }
+
+  public async getStarFromExperienceByExperienceId(experienceId: number) {
+    return await this.prisma.experience.findUnique({
+      where: {
+        id: experienceId,
+      },
+      select: { situation: true, task: true, action: true, result: true },
+    });
+  }
 }


### PR DESCRIPTION
## ⛳️ 기능 구현 배경

---

<!-- 기능 구현 배경에 대해 작성해주세요 -->

![image](https://github.com/depromeet/InsightOut-Server/assets/83271772/f600b0ce-cfe7-4c99-b72e-67d370b10808)

자기소개서 작성 페이지에서 경험 카드를 눌러 S, T, A, R을 볼 수 있도록 구현합니다.

초기 페이지 접근 시 기본적으로 가장 상위에 있는 경험카드에 대해서 S, T, A, R이 있는 화면이 뜨도록 구현이 필요합니다.
이때, 백엔드에서는 해당 경험 카드의 id와 같은 경험카드를 조회해 S, T, A, R, title을 반환하면 됩니다.

+ 경험 카드 조회 API에서 역량 키워드를 통해 조회할 때, experienceStatus를 반환하고 있지 않아서 이것도 추가적으로 반환하도록 수정합니다.

## 😤 기능 구현 내용(Optional)

---

<!-- 기능 구현 내용에 대해 적어주세요 -->

```ts
  public async getStarFromExperienceByExperienceId(experienceId: number): Promise<GetStarFromExperienceResponseDto> {
    const star = await this.experienceRepository.getStarFromExperienceByExperienceId(experienceId);

    // 만약 situation, task, action, result 중에서 하나라도 누락됐다면
    if (!(star.situation && star.task && star.action && star.result)) {
      throw new NotFoundException('There are missing info about S, T, A, R');
    }

    const getStarFromExperienceResponseDto = new GetStarFromExperienceResponseDto(star);
    return getStarFromExperienceResponseDto;
  }
```

## 📭 이슈 번호

---

<!-- 이슈 번호를 남겨주세요 -->

#150 

## 🧐 의견 구하기

---

<!-- 구하고 싶은 의견이 있다면 작성해주세요 -->

## 🙏 P.S

---

<!-- 추가적으로 남기고 싶은 말을 적어주세요 -->

동현님 프롬프팅 화이팅~~~~~~~~~! 난 이제 진짜 할 일 끝났다