### PR TITLE
[Test] get resumes에서 아무 값도 없을 때 테스트

### DIFF
--- a/src/apps/server/resumes/services/resume.service.spec.ts
+++ b/src/apps/server/resumes/services/resume.service.spec.ts
@@ -82,6 +82,9 @@ describe('Resume Service', () => {
     expect(repository).toBeDefined();
   });
 
+  /*************************
+   ********** Get **********
+   *************************/
   describe('get all resumes', () => {
     it('should get all resumes', async () => {
       const resumes = await service.getAllResumes(1, { answer: false });
@@ -104,6 +107,18 @@ describe('Resume Service', () => {
 
       // 서비스 레이어의 결과 객체가 같은지 깊게 비교
       expect(resumes).toStrictEqual(mockResumesReponseDto);
+    });
+
+    it('should not find any raw', async () => {
+      mockResumeRepository.findMany = jest.fn().mockResolvedValue([]);
+
+      // 존재하지 않는 유저로 쿼리 진행
+      const resumes = await service.getAllResumes(2, { answer: true });
+      const resuemsWithAnswer = await service.getAllResumes(2, { answer: true });
+
+      // 값을 찾지 못해야 한다.
+      expect(resumes).toStrictEqual([]);
+      expect(resuemsWithAnswer).toStrictEqual([]);
     });
   });
 });


### PR DESCRIPTION
## ⛳️ 기능 구현 배경

---

<!-- 기능 구현 배경에 대해 작성해주세요 -->

get resumes 에서 값을 못 찾았을 때의 경우를 테스트합니다.

정확히는 `getAllResumes` 메서드에 대해서 테스트했습니다.

## 😤 기능 구현 내용(Optional)

---

<!-- 기능 구현 내용에 대해 적어주세요 -->

## 📭 이슈 번호

---

<!-- 이슈 번호를 남겨주세요 -->

#166 

## 🧐 의견 구하기

---

<!-- 구하고 싶은 의견이 있다면 작성해주세요 -->

테스트 코드를 거의 안 짜봐서 이게 맞나... 싶군요

## 🙏 P.S

---

<!-- 추가적으로 남기고 싶은 말을 적어주세요 -->
