### PR TITLE
[#171] 경험 프로프트 요약 API 생성

### DIFF
--- a/src/apps/server/ai/ai.controller.ts
+++ b/src/apps/server/ai/ai.controller.ts
@@ -18,6 +18,9 @@ import {
   postResumePromptDescriptionMd,
   postResumePromptSuccMd,
   postResumePromptSummaryMd,
+  postResumeSummarySuccMd,
+  postResumeSummarySummaryMd,
+  postSummaryPromptDescriptionMd,
 } from '🔥apps/server/ai/markdown/ai.md';
 import { UserJwtToken } from '🔥apps/server/auth/types/jwt-tokwn.type';
 import { User } from '🔥apps/server/common/decorators/request/user.decorator';
@@ -28,6 +31,8 @@ import { PromptKeywordBodyReqDto } from '🔥apps/server/ai/dto/req/promptKeywor
 import { PromptKeywordResDto } from '🔥apps/server/ai/dto/res/promptKeyword.res.dto';
 import { PromptResumeBodyResDto } from '🔥apps/server/ai/dto/req/promptResume.req.dto';
 import { PromptResumeResDto } from '🔥apps/server/ai/dto/res/promptResume.res.dto';
+import { PromptSummaryBodyReqDto } from '🔥apps/server/ai/dto/req/promptSummary.req.dto';
+import { PromptSummaryResDto } from '🔥apps/server/ai/dto/res/promptSummary.res.dto';
 
 @ApiBearerAuth()
 @UseGuards(JwtAuthGuard)
@@ -103,6 +108,25 @@ export class AiController {
   })
   public async postResumePrompt(@Body() promptKeywordBodyReqDto: PromptResumeBodyResDto): Promise<ResponseEntity<PromptResumeResDto>> {
     const newAi = await this.aiService.postResumePrompt(promptKeywordBodyReqDto);
+
+    return ResponseEntity.OK_WITH_DATA(newAi);
+  }
+
+  @Route({
+    request: {
+      method: Method.POST,
+      path: '/summary',
+    },
+    response: {
+      code: HttpStatus.OK,
+      type: PromptSummaryResDto,
+      description: postResumeSummarySuccMd,
+    },
+    description: postSummaryPromptDescriptionMd,
+    summary: postResumeSummarySummaryMd,
+  })
+  public async postSummaryPrompt(@Body() promptSummaryBodyReqDto: PromptSummaryBodyReqDto): Promise<ResponseEntity<PromptSummaryResDto>> {
+    const newAi = await this.aiService.postSummaryPrompt(promptSummaryBodyReqDto);
 
     return ResponseEntity.OK_WITH_DATA(newAi);
   }

--- a/src/apps/server/ai/ai.service.ts
+++ b/src/apps/server/ai/ai.service.ts
@@ -7,10 +7,12 @@ import { UserJwtToken } from '🔥apps/server/auth/types/jwt-tokwn.type';
 import { CreateAiKeywordsAndResumeBodyReqDto } from '🔥apps/server/ai/dto/req/createAiKeywordsAndResume.req.dto';
 import { PromptKeywordBodyReqDto } from '🔥apps/server/ai/dto/req/promptKeyword.req.dto';
 import { OpenAiService } from '📚libs/modules/open-ai/open-ai.service';
-import { generateKeywordPrompt, generateResumePrompt } from '🔥apps/server/ai/prompt/keywordPrompt';
+import { generateKeywordPrompt, generateResumePrompt, generateSummaryPrompt } from '🔥apps/server/ai/prompt/keywordPrompt';
 import { PromptKeywordResDto } from '🔥apps/server/ai/dto/res/promptKeyword.res.dto';
 import { PromptResumeResDto } from '🔥apps/server/ai/dto/res/promptResume.res.dto';
 import { PromptResumeBodyResDto } from '🔥apps/server/ai/dto/req/promptResume.req.dto';
+import { PromptSummaryBodyReqDto } from '🔥apps/server/ai/dto/req/promptSummary.req.dto';
+import { PromptSummaryResDto } from '🔥apps/server/ai/dto/res/promptSummary.res.dto';
 
 @Injectable()
 export class AiService {
@@ -58,5 +60,13 @@ export class AiService {
     const result = await this.openAiService.promptChatGPT(prompt);
 
     return new PromptResumeResDto(result.choices[CHOICES_IDX].message.content as string);
+  }
+
+  public async postSummaryPrompt(body: PromptSummaryBodyReqDto) {
+    const CHOICES_IDX = 0;
+    const prompt = generateSummaryPrompt(body);
+    const result = await this.openAiService.promptChatGPT(prompt);
+
+    return new PromptSummaryResDto(result.choices[CHOICES_IDX].message.content as string);
   }
 }

--- a/src/apps/server/ai/dto/req/promptSummary.req.dto.ts
+++ b/src/apps/server/ai/dto/req/promptSummary.req.dto.ts
@@ -1,8 +1,7 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { IsNotEmptyString } from '🔥apps/server/common/decorators/validation/isOptionalString.decorator';
-import { IsArray, IsNotEmpty, IsString } from 'class-validator';
 
-export class PromptResumeBodyResDto {
+export class PromptSummaryBodyReqDto {
   @ApiProperty({ example: '개발자와 협업 역량을 쌓기 위해 IT 동아리에 들어감' })
   @IsNotEmptyString(0, 100)
   situation: string;
@@ -18,10 +17,4 @@ export class PromptResumeBodyResDto {
   @ApiProperty({ example: '4개월 만에 출시에 성공하게 됨.' })
   @IsNotEmptyString(0, 100)
   result: string;
-
-  @ApiProperty({ example: ['협업', '린하게 개발'] })
-  @IsNotEmpty()
-  @IsArray()
-  @IsString({ each: true })
-  keywords: string[];
 }

--- a/src/apps/server/ai/dto/res/promptSummary.res.dto.ts
+++ b/src/apps/server/ai/dto/res/promptSummary.res.dto.ts
@@ -1,0 +1,21 @@
+import { Exclude, Expose } from 'class-transformer';
+import { IsNotEmpty, IsString } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
+
+const example =
+  '와! 개발 동아리에 들어간 결과, 구글, 네이버, 카카오 로그인 및 회원가입/탈퇴 등의 기능 구현을 통해 프론트엔드와 백엔드의 상호 통신 개념과 보안강화 방법인 RTR을 배우게 되었습니다. 앞으로도 열심히 공부하고 개발하는 모습 기대합니다!';
+export class PromptSummaryResDto {
+  @Exclude() _summary: string;
+
+  constructor(summary: string) {
+    this._summary = summary;
+  }
+
+  @Expose()
+  @IsNotEmpty()
+  @IsString()
+  @ApiProperty({ example })
+  get resume() {
+    return this._summary;
+  }
+}

--- a/src/apps/server/ai/markdown/ai.md.ts
+++ b/src/apps/server/ai/markdown/ai.md.ts
@@ -46,3 +46,21 @@ ChatGPT 추천 자기소개서가 생성되었습니다 :)
 `;
 
 // -- ChatGPT 추천 자기소개서 생성 API
+
+export const postSummaryPromptDescriptionMd = `
+### ✅ ChatGPT STAR 경험이 요약에 성공하였습니다.
+ChatGPT API를 사용하여 추천 자기소개서를 생성할 때 5~15초 정도 소요됩니다.\n
+
+## Picture
+<img width="515" alt="image" src="https://github.com/depromeet/InsightOut-Server/assets/97580759/b765db66-e16b-4698-99fe-f8e51f487955">
+`;
+
+export const postResumeSummarySummaryMd = `
+✅ ChatGPT 경험 요약 프롬프트 API
+`;
+
+export const postResumeSummarySuccMd = `
+ChatGPT STAR 경험이 요약 되었습니다. :)
+`;
+
+// -- ChatGPT 경험 요약 프롬프트 API

--- a/src/apps/server/ai/prompt/keywordPrompt.ts
+++ b/src/apps/server/ai/prompt/keywordPrompt.ts
@@ -1,12 +1,18 @@
 import { PromptKeywordBodyReqDto } from '🔥apps/server/ai/dto/req/promptKeyword.req.dto';
 import { PromptResumeBodyResDto } from '🔥apps/server/ai/dto/req/promptResume.req.dto';
+import { PromptSummaryBodyReqDto } from '🔥apps/server/ai/dto/req/promptSummary.req.dto';
 
-export const generateKeywordPrompt = (body: PromptKeywordBodyReqDto) => {
+export const generateKeywordPrompt = (body: PromptKeywordBodyReqDto): string => {
   const keywordPrompt = process.env.CHATGPT_KEYWORD_PROMPT;
   return `${keywordPrompt}\n\`\`\`\\nsituation: \`${body.situation}\`\\ntask: \`${body.task}\`\\naction: \`${body.action}\`\\nresult: \`${body.result}\`\\n\`\`\``;
 };
 
-export const generateResumePrompt = (body: PromptResumeBodyResDto) => {
+export const generateResumePrompt = (body: PromptResumeBodyResDto): string => {
   const resumePrompt = process.env.CHATGPT_RESUME_PROMPT;
   return `${resumePrompt}Situation: ${body.situation}\\n\\nTask: ${body.task}\\n\\nAction: ${body.task}\\n\\nResult: ${body.result}\\n\`\`\`\\n\\nKeywords: ${body.keywords}"`;
+};
+
+export const generateSummaryPrompt = (body: PromptSummaryBodyReqDto): string => {
+  const resumePrompt = process.env.CHATGPT_SUMMARY_PROMPT;
+  return `${resumePrompt}Situation: ${body.situation}\\n\\nTask: ${body.task}\\n\\nAction: ${body.task}\\n\\nResult: ${body.result}\\n\n\`\`\`\\n"`;
 };

--- a/src/libs/modules/env/env.enum.ts
+++ b/src/libs/modules/env/env.enum.ts
@@ -55,4 +55,5 @@ export enum EnvEnum {
   // prompt
   CHATGPT_KEYWORD_PROMPT,
   CHATGPT_RESUME_PROMPT,
+  CHATGPT_SUMMARY_PROMPT,
 }


### PR DESCRIPTION
## ⛳️ 기능 구현 배경
- 경험 카드 STAR를 요약하는 API를 구현했습니다.
---

<!-- 기능 구현 배경에 대해 작성해주세요 -->

## 😤 기능 구현 내용(Optional)

---

<!-- 기능 구현 내용에 대해 적어주세요 -->

## 📭 이슈 번호
#171 
---

<!-- 이슈 번호를 남겨주세요 -->

## 🧐 의견 구하기
1.  경험 요약 같은 경우에는 Chat GPT의 요약본을 받고 바로 analysis에 저장하는 것 까지 포함 해야 될 거 같은데 어떻게 생각하시나요?!
     - 아래 사진 처럼 Chat GPT요청 이후에 바로 카드를 보여주기 때문에 이 시점에 저장을 해야 될 거 같아요!
![image](https://github.com/depromeet/InsightOut-Server/assets/97580759/d73b1715-9e2c-404c-96e5-b1cb3b1f23e4)

2. 다른 방법은 요약된 내용을 받고 다시 upsert API로 업데이트를 하는 것입니다!
- 인사이트를 하사하여 주세요 🙏 
---

<!-- 구하고 싶은 의견이 있다면 작성해주세요 -->

## 🙏 P.S

---

<!-- 추가적으로 남기고 싶은 말을 적어주세요 -->
