### PR TITLE
[Hotfix] guard property 접근 시 발생하는 에러 수정

### DIFF
--- a/src/apps/server/common/exceptions/unknown.exception.ts
+++ b/src/apps/server/common/exceptions/unknown.exception.ts
@@ -6,7 +6,7 @@ export class UnknownException extends BaseException {
     super({
       statusCode: HttpStatus.INTERNAL_SERVER_ERROR,
       title: properties.title,
-      message: properties.message,
+      message: properties?.message,
       raw: properties.raw,
     });
   }

--- a/src/apps/server/common/guards/jwt-auth.guard.ts
+++ b/src/apps/server/common/guards/jwt-auth.guard.ts
@@ -19,7 +19,7 @@ export class JwtAuthGuard extends AuthGuard('jwt') {
       throw new UnauthorizedException(info.message);
     }
 
-    if (info.message === 'No auth token') {
+    if (info?.message === 'No auth token') {
       throw new NoAuthTokenException();
     }
 

--- a/src/apps/server/common/guards/jwt-refresh.guard.ts
+++ b/src/apps/server/common/guards/jwt-refresh.guard.ts
@@ -18,13 +18,14 @@ export class JwtRefreshGuard extends AuthGuard('refresh') {
       throw new UnauthorizedException(info.message);
     }
 
-    if (info.message === 'No auth token') {
+    if (info?.message === 'No auth token') {
       throw new NoAuthTokenException('Token not exist. It could be because it expired past its maxage.');
     }
 
     if (!user) {
       throw new UnauthorizedException('적절하지 않은 요청입니다.');
     }
+
     return user;
   }
 }


### PR DESCRIPTION
## ⛳️ 기능 구현 배경

---

<!-- 기능 구현 배경에 대해 작성해주세요 -->

TypeError가 발생하여 액세스 토큰 재발급 시 에러가 뜨는 부분을 수정합니다.

## 😤 기능 구현 내용(Optional)

---

<!-- 기능 구현 내용에 대해 적어주세요 -->

```ts
    if (info?.message === 'No auth token') {
      throw new NoAuthTokenException();
    }
```

옵셔널 프로퍼티로 바꾸고 바로 해결했습니다.

## 📭 이슈 번호

---

<!-- 이슈 번호를 남겨주세요 -->

#202 

## 🧐 의견 구하기

---

<!-- 구하고 싶은 의견이 있다면 작성해주세요 -->

## 🙏 P.S

---

<!-- 추가적으로 남기고 싶은 말을 적어주세요 -->
