### PR TITLE
[Fix] 경험카드 조회 시 모든 유저의 경험카드 가져오는 버그 수정

### DIFF
--- a/src/apps/server/experiences/controllers/experience.controller.ts
+++ b/src/apps/server/experiences/controllers/experience.controller.ts
@@ -98,7 +98,7 @@ export class ExperienceController {
     let experience;
 
     if (getExperienceRequestQueryDto.capabilityId) {
-      experience = await this.experienceService.getExperienceByCapability(getExperienceRequestQueryDto);
+      experience = await this.experienceService.getExperienceByCapability(user.userId, getExperienceRequestQueryDto);
     } else {
       // TODO 추후 전체 모아보기를 위해 수정 필요
       experience = await this.experienceService.getExperiencesByUserId(user.userId, getExperienceRequestQueryDto);

--- a/src/apps/server/experiences/services/experience.service.ts
+++ b/src/apps/server/experiences/services/experience.service.ts
@@ -53,9 +53,12 @@ export class ExperienceService {
     }
   }
 
-  public async getExperienceByCapability(query: GetExperienceRequestQueryDto): Promise<GetExperienceByCapabilityResponseDto[]> {
+  public async getExperienceByCapability(
+    userId: number,
+    query: GetExperienceRequestQueryDto,
+  ): Promise<GetExperienceByCapabilityResponseDto[]> {
     const { capabilityId, last, ...select } = query;
-    const experience = await this.experienceRepository.getExperienceByCapability(capabilityId, select);
+    const experience = await this.experienceRepository.getExperienceByCapability(userId, capabilityId, select);
     if (!experience.length) {
       throw new NotFoundException('Experience not found');
     }

--- a/src/libs/modules/database/repositories/experience.repository.ts
+++ b/src/libs/modules/database/repositories/experience.repository.ts
@@ -48,10 +48,10 @@ export class ExperienceRepository implements ExperienceRepositoryInterface {
     });
   }
 
-  public async getExperienceByCapability(capabilityId: number, select: Partial<ExperienceSelect>) {
+  public async getExperienceByCapability(userId: number, capabilityId: number, select: Partial<ExperienceSelect>) {
     // TODO ai 역량 키워드가 적용되면 해당 키워드도 함께 쿼리로 가져와야 함.
     const experiences = await this.prisma.experience.findMany({
-      where: { ExperienceCapability: { some: { capabilityId: { equals: capabilityId } } } },
+      where: { userId, ExperienceCapability: { some: { capabilityId: { equals: capabilityId } } } },
       select: {
         id: true,
         title: true,


### PR DESCRIPTION
## ⛳️ 기능 구현 배경

---

<!-- 기능 구현 배경에 대해 작성해주세요 -->

경험카드 조회할 때 userId를 where로 안 돌려서 모든 유저의 경험카드를 조회해버렸습니다.

## 😤 기능 구현 내용(Optional)

---

<!-- 기능 구현 내용에 대해 적어주세요 -->

경험카드 조회 시 userId를 검사해서 해당 유저의 경험카드만 가져오도록 수정했습니다.

```ts
  public async getExperienceByCapability(userId: number, capabilityId: number, select: Partial<ExperienceSelect>) {
    // TODO ai 역량 키워드가 적용되면 해당 키워드도 함께 쿼리로 가져와야 함.
    const experiences = await this.prisma.experience.findMany({
      where: { userId, ExperienceCapability: { some: { capabilityId: { equals: capabilityId } } } },
      select: {
        id: true,
        title: true,
```

## 📭 이슈 번호

---

<!-- 이슈 번호를 남겨주세요 -->

#201 

## 🧐 의견 구하기

---

<!-- 구하고 싶은 의견이 있다면 작성해주세요 -->

## 🙏 P.S

---

<!-- 추가적으로 남기고 싶은 말을 적어주세요 -->
