### PR TITLE
Feature/#210/create null experience

### DIFF
--- a/src/apps/server/experiences/controllers/experience.controller.ts
+++ b/src/apps/server/experiences/controllers/experience.controller.ts
@@ -15,7 +15,13 @@ import {
 import { ResponseEntity } from '📚libs/utils/respone.entity';
 import { GetExperienceNotFoundErrorResDto, GetExperienceResDto } from '../dto/res/getExperience.res.dto';
 import { Method } from '📚libs/enums/method.enum';
-import { getExperienceSuccMd, upsertExperienceSuccMd } from '🔥apps/server/experiences/markdown/experience.md';
+import {
+  createExperienceDescriptionMd,
+  createExperienceSuccMd,
+  createExperienceSummaryMd,
+  getExperienceSuccMd,
+  upsertExperienceSuccMd,
+} from '🔥apps/server/experiences/markdown/experience.md';
 import { GetExperienceRequestQueryDto } from '🔥apps/server/experiences/dto/req/get-experience.dto';
 import {
   GetCountOfExperienceAndCapabilityDescriptionMd,
@@ -40,6 +46,7 @@ import {
   GetStarFromExperienceResponseDescriptionMd,
   GetStarFromExperienceSummaryMd,
 } from '🔥apps/server/experiences/markdown/get-star-from-experience.md';
+import { CreateExperienceResDto } from '🔥apps/server/experiences/dto/res/createExperience.res.dto';
 
 @ApiBearerAuth()
 @UseGuards(JwtAuthGuard)
@@ -52,6 +59,25 @@ import {
 export class ExperienceController {
   constructor(private readonly experienceService: ExperienceService) {}
 
+  @Route({
+    request: {
+      method: Method.POST,
+      path: '/',
+    },
+    response: {
+      code: HttpStatus.CREATED,
+      type: CreateExperienceResDto,
+      description: createExperienceSuccMd,
+    },
+    description: createExperienceDescriptionMd,
+    summary: createExperienceSummaryMd,
+  })
+  public async create(@User() user: UserJwtToken): Promise<ResponseEntity<CreateExperienceResDto>> {
+    const experience = await this.experienceService.create(user);
+
+    return ResponseEntity.CREATED_WITH_DATA(experience);
+  }
+
   @ApiBadRequestResponse({
     description: '⛔ 유효성 검사에 실패하였습니다. 타입을 확인해주세요 :)',
     type: BadRequestErrorResDto,
@@ -62,7 +88,7 @@ export class ExperienceController {
   })
   @Route({
     request: {
-      method: Method.POST,
+      method: Method.PUT,
       path: '/',
     },
     response: {

--- a/src/apps/server/experiences/dto/res/createExperience.res.dto.ts
+++ b/src/apps/server/experiences/dto/res/createExperience.res.dto.ts
@@ -1,0 +1,172 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { Exclude, Expose } from 'class-transformer';
+import { IsOptionalNumber } from '🔥apps/server/common/decorators/validation/isOptionalNumber.decorator';
+import { IsOptionalString } from '🔥apps/server/common/decorators/validation/isOptionalString.decorator';
+import { dateValidation } from '🔥apps/server/common/consts/date-validation.const';
+import { IsEnum, IsOptional, Matches } from 'class-validator';
+import { Experience, ExperienceInfo, ExperienceStatus } from '@prisma/client';
+
+export class CreateExperienceInfoResDto {
+  @Exclude() private _experienceInfoId: number;
+  @Exclude() private _experienceRole: string;
+  @Exclude() private _motivation: string;
+  @Exclude() private _utilization: string;
+  @Exclude() private _analysis: string;
+
+  set setExperienceInfoId(experienceInfoId: number) {
+    this._experienceInfoId = experienceInfoId;
+  }
+
+  set setMotivation(motivation: string) {
+    this._motivation = motivation;
+  }
+
+  set setExperienceRole(experienceRole: string) {
+    this._experienceRole = experienceRole;
+  }
+
+  set setUtilization(utiliaztion: string) {
+    this._utilization = utiliaztion;
+  }
+
+  set setAnalysis(analysis: string) {
+    this._analysis = analysis;
+  }
+
+  @ApiProperty({ example: 1 })
+  @IsOptionalNumber()
+  get experienceInfoId(): number {
+    return this._experienceInfoId;
+  }
+
+  @ApiPropertyOptional({
+    example: null,
+  })
+  @IsOptionalString(0, 100)
+  get motivation(): string {
+    return this._motivation;
+  }
+
+  @ApiPropertyOptional({
+    example: null,
+  })
+  @IsOptionalString(0, 100)
+  get experienceRole(): string {
+    return this._experienceRole;
+  }
+
+  @ApiPropertyOptional({
+    example: null,
+  })
+  @IsOptionalString(0, 100)
+  get utilization(): string {
+    return this._utilization;
+  }
+
+  @ApiPropertyOptional({
+    example: null,
+  })
+  @IsOptionalString(0, 100)
+  get analysis(): string {
+    return this._analysis;
+  }
+}
+
+export class CreateExperienceResDto {
+  @Exclude() private readonly _experienceId: number;
+  @Exclude() private readonly _title: string;
+  @Exclude() private readonly _situation: string;
+  @Exclude() private readonly _task: string;
+  @Exclude() private readonly _action: string;
+  @Exclude() private readonly _result: string;
+  @Exclude() private readonly _startDate: Date;
+  @Exclude() private readonly _endDate: Date;
+  @Exclude() private readonly _experienceStatus: ExperienceStatus;
+  @Exclude() private readonly _experienceInfo: CreateExperienceInfoResDto;
+
+  constructor(experience: Experience, experienceInfo: ExperienceInfo) {
+    this._experienceId = experience.id;
+    this._title = experience.title;
+    this._startDate = experience.startDate;
+    this._endDate = experience.endDate;
+    this._situation = experience.situation;
+    this._task = experience.task;
+    this._action = experience.action;
+    this._result = experience.result;
+
+    const experienceInfoRes = new CreateExperienceInfoResDto();
+    experienceInfoRes.setExperienceInfoId = experienceInfo.id;
+    experienceInfoRes.setExperienceRole = experienceInfo.experienceRole;
+    experienceInfoRes.setMotivation = experienceInfo.motivation;
+    experienceInfoRes.setUtilization = experienceInfo.utilization;
+    experienceInfoRes.setAnalysis = experienceInfo.analysis;
+
+    this._experienceInfo = experienceInfoRes;
+  }
+
+  @ApiProperty({ example: 1 })
+  @IsOptionalNumber()
+  get experienceId(): number {
+    return this._experienceId;
+  }
+
+  @ApiPropertyOptional({ example: null })
+  @IsOptionalString(0, 100)
+  get title(): string {
+    return this._title;
+  }
+
+  @ApiPropertyOptional({ example: null })
+  @IsOptionalString(0, 7)
+  @Matches(dateValidation.YYYY_MM)
+  get startDate(): Date {
+    return this._startDate;
+  }
+
+  @ApiPropertyOptional({ example: null })
+  @IsOptionalString(0, 7)
+  @Matches(dateValidation.YYYY_MM)
+  get endDate(): Date {
+    return this._endDate;
+  }
+
+  @ApiPropertyOptional({ example: null })
+  @IsOptionalString(0, 100)
+  get situation(): string {
+    return this._situation;
+  }
+
+  @ApiPropertyOptional({ example: null })
+  @IsOptionalString(0, 100)
+  get task(): string {
+    return this._task;
+  }
+
+  @ApiPropertyOptional({ example: null })
+  @IsOptionalString(0, 100)
+  get action(): string {
+    return this._action;
+  }
+
+  @ApiPropertyOptional({ example: null })
+  @IsOptionalString(0, 100)
+  get result(): string {
+    return this._result;
+  }
+  @ApiPropertyOptional({
+    example: ExperienceStatus.INPROGRESS,
+    default: ExperienceStatus.INPROGRESS,
+  })
+  @IsEnum(ExperienceStatus)
+  @IsOptional()
+  @Expose()
+  get experienceStatus(): ExperienceStatus {
+    return this._experienceStatus;
+  }
+
+  @ApiProperty({ type: CreateExperienceInfoResDto })
+  @Expose()
+  get experienceInfo(): CreateExperienceInfoResDto {
+    return this._experienceInfo;
+  }
+}

--- a/src/apps/server/experiences/markdown/experience.md.ts
+++ b/src/apps/server/experiences/markdown/experience.md.ts
@@ -1,3 +1,14 @@
+export const createExperienceDescriptionMd = `
+### ✅ 경험 분해 생성에 성공하였습니다.
+해당 API를 사용하시면 아무 내용이 들어가 있지 않은 경험 분해를 생성한 뒤 반환합니다.\n
+최초 상태는 \`INPROGRESS\`입니다.
+`;
+
+export const createExperienceSummaryMd = '✅ 경험 정보 생성 API';
+export const createExperienceSuccMd = '✅ 경험 정보 생성에 성공하였습니다.';
+
+//-- createExperience
+
 export const getExperienceSuccMd = `
 ### ✅ 경험 분해 조회에 성공했습니다.
 s, t, a, r의 경험 카드 내용을 조회하기 위해서 각각 querystring에 boolean 값을 입력합니다.\n

--- a/src/libs/modules/database/repositories/experience.repository.ts
+++ b/src/libs/modules/database/repositories/experience.repository.ts
@@ -4,6 +4,7 @@ import { Experience, ExperienceInfo, ExperienceStatus } from '@prisma/client';
 import { ExperienceSelect } from '🔥apps/server/experiences/interface/experience-select.interface';
 import { ExperienceRepositoryInterface } from '🔥apps/server/experiences/interface/experience-repository.interface';
 import { ExperienceCardType } from '🔥apps/server/experiences/types/experience-card.type';
+import { UserJwtToken } from '🔥apps/server/auth/types/jwt-tokwn.type';
 
 @Injectable()
 export class ExperienceRepository implements ExperienceRepositoryInterface {


### PR DESCRIPTION
## ⛳️ 기능 구현 배경
- 빈 경험 분해 생성 API
---

<!-- 기능 구현 배경에 대해 작성해주세요 -->

## 😤 기능 구현 내용(Optional)
- 경험 분해 빈 껍데기를 만드는 API가 필요해 구현했습니다.
- 경험 분해 상태(INPROGRESS), 유저 연결(userId) 를 제외하고는 전부 null이 들어가 생성됩니다.
---

<!-- 기능 구현 내용에 대해 적어주세요 -->

## 📭 이슈 번호
#210 
---

<!-- 이슈 번호를 남겨주세요 -->

## 🧐 의견 구하기

---

<!-- 구하고 싶은 의견이 있다면 작성해주세요 -->

## 🙏 P.S
- 사랑해요 이성태!
- 화이팅 이성태!
- 어려운 거 있으면 나만 찾아 이성태!
---

<!-- 추가적으로 남기고 싶은 말을 적어주세요 -->
