### PR TITLE
[Feature] 직무 선택 온보딩 경험 여부 컬럼 추가 & 회원가입/로그인 시 반환되는 온보딩 값에 직무 선택 온보딩 경험 여부 추가

### DIFF
--- a/src/apps/server/onboarding/dtos/get-onboarding.dto.ts
+++ b/src/apps/server/onboarding/dtos/get-onboarding.dto.ts
@@ -4,12 +4,14 @@ import { Exclude, Expose } from 'class-transformer';
 import { IsBoolean, IsNotEmpty } from 'class-validator';
 
 export class GetAllOnboardingsResponseDto {
+  @Exclude() private readonly _field: boolean;
   @Exclude() private readonly _experience: boolean;
   @Exclude() private readonly _experienceStepper: boolean;
   @Exclude() private readonly _resume: boolean;
   @Exclude() private readonly _collection: boolean;
 
   constructor(onboarding: Onboarding) {
+    this._field = onboarding.field;
     this._experience = onboarding.experience;
     this._experienceStepper = onboarding.experienceStepper;
     this._resume = onboarding.resume;
@@ -18,7 +20,21 @@ export class GetAllOnboardingsResponseDto {
 
   @Expose()
   @ApiProperty({
+    description: '직무 선택 온보딩 여부',
+    example: false,
+    type: Boolean,
+  })
+  @IsBoolean()
+  @IsNotEmpty()
+  get field(): boolean {
+    return this._field;
+  }
+
+  @Expose()
+  @ApiProperty({
     description: '경험 분해 온보딩 여부',
+    example: false,
+    type: Boolean,
   })
   @IsBoolean()
   @IsNotEmpty()
@@ -29,6 +45,8 @@ export class GetAllOnboardingsResponseDto {
   @Expose()
   @ApiProperty({
     description: '경험 분해 스텝퍼 온보딩 여부',
+    example: false,
+    type: Boolean,
   })
   @IsBoolean()
   @IsNotEmpty()
@@ -39,6 +57,8 @@ export class GetAllOnboardingsResponseDto {
   @Expose()
   @ApiProperty({
     description: '자기소개서 온보딩 여부',
+    example: false,
+    type: Boolean,
   })
   @IsBoolean()
   @IsNotEmpty()
@@ -49,6 +69,8 @@ export class GetAllOnboardingsResponseDto {
   @Expose()
   @ApiProperty({
     description: '모아보기 온보딩 여부',
+    example: false,
+    type: Boolean,
   })
   @IsBoolean()
   @IsNotEmpty()

--- a/src/apps/server/onboarding/dtos/patch-onboarding.dto.ts
+++ b/src/apps/server/onboarding/dtos/patch-onboarding.dto.ts
@@ -6,6 +6,16 @@ import { IsTrue } from '🔥apps/server/common/decorators/validation/isTrue.deco
 
 export class PatchOnboardingRequestBodyDto {
   @ApiPropertyOptional({
+    description: '직무 선택 온보딩 경험 여부',
+    example: true,
+    type: Boolean,
+  })
+  @IsTrue()
+  @IsNotEmpty()
+  @IsOptional()
+  field?: boolean;
+
+  @ApiPropertyOptional({
     description: '경험분해 온보딩 경험 여부',
     example: true,
     type: Boolean,
@@ -48,16 +58,31 @@ export class PatchOnboardingRequestBodyDto {
 }
 
 export class PatchOnboardingResponseDto {
+  @Exclude() private readonly _field?: boolean | undefined;
   @Exclude() private readonly _experience?: boolean | undefined;
   @Exclude() private readonly _experienceStepper?: boolean | undefined;
   @Exclude() private readonly _resume?: boolean | undefined;
   @Exclude() private readonly _collection?: boolean | undefined;
 
   constructor(onboarding: Onboarding) {
+    this._field = onboarding.field;
     this._experience = onboarding.experience;
     this._experienceStepper = onboarding.experienceStepper;
     this._resume = onboarding.resume;
     this._collection = onboarding.collection;
+  }
+
+  @Expose()
+  @ApiPropertyOptional({
+    description: '직무 선택 온보딩 경험 여부',
+    example: true,
+    type: Boolean,
+  })
+  @IsBoolean()
+  @IsNotEmpty()
+  @IsOptional()
+  get field(): boolean {
+    return this._field;
   }
 
   @Expose()

--- a/src/libs/modules/database/schema.prisma
+++ b/src/libs/modules/database/schema.prisma
@@ -25,12 +25,12 @@ model User {
   deletedAt DateTime? @map("deleted_at") @db.Timestamptz
   nickname  String    @db.VarChar(10)
 
-  UserInfo     UserInfo?
-  Onboarding   Onboarding?
-  Resume       Resume[]
-  AiResumes    AiResume[]
-  Experiences  Experience[]
-  Capability   Capability[]
+  UserInfo    UserInfo?
+  Onboarding  Onboarding?
+  Resume      Resume[]
+  AiResumes   AiResume[]
+  Experiences Experience[]
+  Capability  Capability[]
 
   @@map("user")
 }
@@ -86,6 +86,7 @@ model UserInfo {
 model Onboarding {
   userId Int @id
 
+  field             Boolean @default(false) // 직무 선택 온보딩
   experience        Boolean @default(false) // 경험분해 온보딩 여부
   experienceStepper Boolean @default(false) @map("experience_stepper") // 경험분해 stepper 온보딩 여부
   resume            Boolean @default(false) // 자기소개서 작성 온보딩 여부
@@ -131,28 +132,27 @@ model AiResume {
   userId       Int @map("user_id")
   experienceId Int @unique @map("experience_id") // 경험 id
 
-  User           User           @relation(references: [id], fields: [userId], onDelete: Cascade)
-  Experience     Experience     @relation(references: [id], fields: [experienceId], onDelete: Cascade)
+  User       User       @relation(references: [id], fields: [userId], onDelete: Cascade)
+  Experience Experience @relation(references: [id], fields: [experienceId], onDelete: Cascade)
 
   AiResumeCapability AiResumeCapability[]
 
   @@map("ai_resume")
 }
 
-
 // ********************************
 // ****** AI 추천 자기소개서 문항 ******
 // ********************************
 model AiRecommendQuestion {
-  id      Int    @id @default(autoincrement())
-  title  String? @db.VarChar(300) // 문항 제목
+  id    Int     @id @default(autoincrement())
+  title String? @db.VarChar(300) // 문항 제목
 
   createdAt DateTime @default(now()) @map("created_at") @db.Timestamptz
   updatedAt DateTime @updatedAt @map("updated_at") @db.Timestamptz
 
   experienceId Int @map("experience_id") // 경험 id
 
-  Experience     Experience     @relation(references: [id], fields: [experienceId], onDelete: Cascade)
+  Experience Experience @relation(references: [id], fields: [experienceId], onDelete: Cascade)
 
   @@map("ai_recommend_question")
 }
@@ -190,11 +190,11 @@ model Experience {
 
   experienceStatus ExperienceStatus @default(INPROGRESS) // 경험 분해 진행 척도 디폴트 inprogress
 
-  situation String? @db.VarChar(100) // S: Situation, 계기와 배경
-  task      String? @db.VarChar(100) // T: Task, 과제 및 목표
-  action    String? @db.VarChar(100) // A: Action, 행동
-  result    String? @db.VarChar(100) // R: Result, 결과
-  summaryKeywords  String[] @map("summary_keywords")// 요약 키워드 배열
+  situation       String?  @db.VarChar(100) // S: Situation, 계기와 배경
+  task            String?  @db.VarChar(100) // T: Task, 과제 및 목표
+  action          String?  @db.VarChar(100) // A: Action, 행동
+  result          String?  @db.VarChar(100) // R: Result, 결과
+  summaryKeywords String[] @map("summary_keywords") // 요약 키워드 배열
 
   createdAt DateTime @default(now()) @map("created_at") @db.Timestamptz
   updatedAt DateTime @updatedAt @map("updated_at") @db.Timestamptz
@@ -215,7 +215,6 @@ enum ExperienceStatus {
   INPROGRESS // 진행중
   DONE // 끝
 }
-
 
 // ********************************
 // *********** 경험 정보 ************
@@ -243,14 +242,14 @@ model ExperienceInfo {
 // ********************************
 
 model Capability {
-  id      Int    @id @default(autoincrement()) // 역량 id
-  keyword String @db.VarChar(10) // 역량 키워드
+  id          Int         @id @default(autoincrement()) // 역량 id
+  keyword     String      @db.VarChar(10) // 역량 키워드
   keywordType KeywordType
-  userId Int @map("user_id")
+  userId      Int         @map("user_id")
 
   User                 User                   @relation(references: [id], fields: [userId], onDelete: Cascade)
   ExperienceCapability ExperienceCapability[]
-  AiResumeCapability AiResumeCapability[]
+  AiResumeCapability   AiResumeCapability[]
 
   @@map("capability")
 }
@@ -260,7 +259,6 @@ enum KeywordType {
   AI // ai 역량 키워드
   USER // user가 선택한 키워드
 }
-
 
 model ExperienceCapability {
   experienceId Int @map("experience_id")
@@ -273,12 +271,11 @@ model ExperienceCapability {
   @@map("experience_capability")
 }
 
-
 model AiResumeCapability {
-  aiResumeId Int @map("ai_resume_id")
+  aiResumeId   Int @map("ai_resume_id")
   capabilityId Int @map("capability_id")
 
-  AiResume AiResume @relation(references: [id], fields: [aiResumeId])
+  AiResume   AiResume   @relation(references: [id], fields: [aiResumeId])
   Capability Capability @relation(references: [id], fields: [capabilityId])
 
   @@id([aiResumeId, capabilityId])


### PR DESCRIPTION
## ⛳️ 기능 구현 배경

---

<!-- 기능 구현 배경에 대해 작성해주세요 -->

직무 온보딩 선택 여부가 필요해서 추가합니다.

회원가입 하는 유저와 로그인 하는 유저를 구분하는 데 필요하다고 하십니다.

## 😤 기능 구현 내용(Optional)

---

<!-- 기능 구현 내용에 대해 적어주세요 -->

```ts
// 회원가입 시 모든 온보딩 처리를 생성합니다.
model Onboarding {
  userId Int @id
  field             Boolean @default(false) // 직무 선택 온보딩
  experience        Boolean @default(false) // 경험분해 온보딩 여부
  experienceStepper Boolean @default(false) @map("experience_stepper") // 경험분해 stepper 온보딩 여부
  resume            Boolean @default(false) // 자기소개서 작성 온보딩 여부
  collection        Boolean @default(false) // 모아보기 온보딩 여부
  User User @relation(references: [id], fields: [userId])
  @@map("onboarding")
}
```
업데이트 된 온보딩 여부 테이블입니다.

## 📭 이슈 번호

---

<!-- 이슈 번호를 남겨주세요 -->

#230 

## 🧐 의견 구하기

---

<!-- 구하고 싶은 의견이 있다면 작성해주세요 -->

## 🙏 P.S

---

<!-- 추가적으로 남기고 싶은 말을 적어주세요 -->
