### PR TITLE
[#248] 경험 분해 단일 조회시 updatedAt 내려주기

### DIFF
--- a/src/apps/server/experiences/dto/res/getExperienceById.res.dto.ts
+++ b/src/apps/server/experiences/dto/res/getExperienceById.res.dto.ts
@@ -1,6 +1,17 @@
 import { Exclude, Expose, Type } from 'class-transformer';
 import { Experience, ExperienceStatus, KeywordType } from '@prisma/client';
-import { ArrayMaxSize, IsArray, IsEnum, IsNotEmpty, IsOptional, IsString, Matches, MaxLength, ValidateNested } from 'class-validator';
+import {
+  ArrayMaxSize,
+  IsArray,
+  IsDate,
+  IsEnum,
+  IsNotEmpty,
+  IsOptional,
+  IsString,
+  Matches,
+  MaxLength,
+  ValidateNested,
+} from 'class-validator';
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { IsOptionalNumber } from '🔥apps/server/common/decorators/validation/isCustomNumber.decorator';
 import { IsOptionalString } from '🔥apps/server/common/decorators/validation/isCustomString.decorator';
@@ -87,6 +98,7 @@ export class GetExperienceByIdResDto {
   @Exclude() _result: string;
   @Exclude() _experienceStatus: ExperienceStatus;
   @Exclude() _summaryKeywords: string[];
+  @Exclude() _updatedAt: Date;
   @Exclude() _ExperienceInfo: GetExperienceInfoResDto;
   @Exclude() _AiResume: AiResume;
 
@@ -101,6 +113,7 @@ export class GetExperienceByIdResDto {
     this._result = experience.result;
     this._experienceStatus = experience.experienceStatus;
     this._summaryKeywords = experience.summaryKeywords;
+    this._updatedAt = experience.updatedAt;
     this._ExperienceInfo = experience.ExperienceInfo;
     this._AiResume = experience.AiResume;
   }
@@ -172,6 +185,14 @@ export class GetExperienceByIdResDto {
   @IsOptional()
   get summaryKeywords(): string[] {
     return this._summaryKeywords;
+  }
+
+  @IsDate()
+  @IsNotEmpty()
+  @Expose()
+  @ApiPropertyOptional({ example: '2023-07-01T09:11:30.599Z' })
+  get updatedAt(): Date {
+    return this._updatedAt;
   }
 
   @Expose()

--- a/src/libs/modules/database/repositories/experience.repository.ts
+++ b/src/libs/modules/database/repositories/experience.repository.ts
@@ -24,6 +24,7 @@ export class ExperienceRepository implements ExperienceRepositoryInterface {
         result: true,
         experienceStatus: true,
         summaryKeywords: true,
+        updatedAt: true,
         ExperienceInfo: { select: { experienceId: true, experienceRole: true, motivation: true, utilization: true } },
         AiResume: {
           select: { content: true, AiResumeCapability: { select: { Capability: { select: { keyword: true, keywordType: true } } } } },


### PR DESCRIPTION
## ⛳️ 기능 구현 배경
- 경험 분해 단일 조회시 updatedAt을 내려달라는 요청 사항을 반영하였습니다.
---

<!-- 기능 구현 배경에 대해 작성해주세요 -->

## 😤 기능 구현 내용(Optional)
- updatedAt이 함께 내려갑니다!
<img width="490" alt="image" src="https://github.com/depromeet/InsightOut-Server/assets/97580759/73b4a080-51af-4994-8917-24759b614041">

---

<!-- 기능 구현 내용에 대해 적어주세요 -->

## 📭 이슈 번호

---

<!-- 이슈 번호를 남겨주세요 -->

## 🧐 의견 구하기

---

<!-- 구하고 싶은 의견이 있다면 작성해주세요 -->

## 🙏 P.S
- @stae1102 저희 utilization 사라진 걸로 알고 있는데 제가 맞다면 이슈 만들어서 모두 삭제할 수 있도록 하겠습니다!
- 컨펌 부탁드립니다 :)
---

<!-- 추가적으로 남기고 싶은 말을 적어주세요 -->
