### PR TITLE
[Feature] ai 키워드 종류의 추천을 2개까지만 추천하도록 개선

### DIFF
--- a/src/apps/server/ai/ai.service.ts
+++ b/src/apps/server/ai/ai.service.ts
@@ -53,7 +53,7 @@ export class AiService {
     const prompt = generateAiKeywordPrompt(body);
     const aiKeywords = await this.openAiService.promptChatGPT(prompt);
 
-    const parseAiKeywords = this.parsingPromptResult(aiKeywords);
+    const parseAiKeywords = this.parsingPromptResult(aiKeywords).slice(0, 2);
 
     // capability생성
     const capabilityInfos = parseAiKeywords.map((keyword) => {
@@ -130,7 +130,7 @@ export class AiService {
       this.openAiService.promptChatGPT(aiSummaryKeywords),
     ]);
 
-    const parseKeywords = this.parsingPromptResult(keywords);
+    const parseKeywords = this.parsingPromptResult(keywords).slice(0, 2);
     const aiRecommendResume = generateRecommendQuestionsPrompt(parseKeywords);
 
     // analysis, keyword 업데이트
@@ -144,7 +144,7 @@ export class AiService {
 
     // 추천 Resume 저장 Start
     const recommendQuestions = await this.openAiService.promptChatGPT(aiRecommendResume);
-    const parseRecommendQuestions: string[] = this.parsingPromptResult(recommendQuestions);
+    const parseRecommendQuestions: string[] = this.parsingPromptResult(recommendQuestions).slice(0, 2);
     const aiRecommendInfos = parseRecommendQuestions.map((question) => {
       return {
         experienceId: body.experienceId,


### PR DESCRIPTION
## ⛳️ 기능 구현 배경

---

<!-- 기능 구현 배경에 대해 작성해주세요 -->

ai 키워드 추천이 종종 2개까지 돼서 이 부분 수정합니다.

## 😤 기능 구현 내용(Optional)

---

<!-- 기능 구현 내용에 대해 적어주세요 -->

모든 ai 추천에 slice(0, 2) 프로토타입 메서드로 2개 이하로 추출합니다.

## 📭 이슈 번호

---

<!-- 이슈 번호를 남겨주세요 -->

#273 

## 🧐 의견 구하기

---

<!-- 구하고 싶은 의견이 있다면 작성해주세요 -->

## 🙏 P.S

---

<!-- 추가적으로 남기고 싶은 말을 적어주세요 -->
