### PR TITLE
[Feature] 카드 뒷면 데이터에 필요한 유저 직무 역량 키워드 프로퍼티 추가

### DIFF
--- a/src/apps/server/ai/ai.service.ts
+++ b/src/apps/server/ai/ai.service.ts
@@ -48,7 +48,7 @@ export class AiService {
       where: { experienceId: body.experienceId },
       select: { AiResumeCapability: true },
     });
-    if (aiCapability) throw new ConflictException('이미 ai Capability가 존재합니다.');
+    if (aiCapability?.AiResumeCapability?.length) throw new ConflictException('이미 ai Capability가 존재합니다.');
 
     const prompt = generateAiKeywordPrompt(body);
     const aiKeywords = await this.openAiService.promptChatGPT(prompt);

--- a/src/apps/server/experiences/dto/res/getExperienceById.res.dto.ts
+++ b/src/apps/server/experiences/dto/res/getExperienceById.res.dto.ts
@@ -92,8 +92,8 @@ export class GetExperienceByIdResDto {
   @Exclude() _experienceCapabilityKeywords: string[];
   @Exclude() _summaryKeywords: string[];
   @Exclude() _updatedAt: Date;
-  @Exclude() _experienceInfo: GetExperienceInfoResDto;
-  @Exclude() _aiResume: AiResume;
+  @Exclude() _ExperienceInfo: GetExperienceInfoResDto;
+  @Exclude() _AiResume: AiResume;
 
   constructor(
     experience: Partial<
@@ -118,8 +118,8 @@ export class GetExperienceByIdResDto {
     );
     this._summaryKeywords = experience.summaryKeywords;
     this._updatedAt = experience.updatedAt;
-    this._experienceInfo = experience.ExperienceInfo;
-    this._aiResume = experience.AiResume;
+    this._ExperienceInfo = experience.ExperienceInfo;
+    this._AiResume = experience.AiResume;
   }
   @ApiProperty({ example: 1 })
   @IsOptionalNumber()
@@ -245,7 +245,7 @@ export class GetExperienceByIdResDto {
     ],
   })
   get AiResume(): AiResume {
-    return this._aiResume;
+    return this._AiResume;
   }
 
   @Expose()
@@ -259,6 +259,6 @@ export class GetExperienceByIdResDto {
     },
   })
   get ExperienceInfo(): GetExperienceInfoResDto {
-    return this._experienceInfo;
+    return this._ExperienceInfo;
   }
 }

--- a/src/apps/server/experiences/dto/res/getExperienceById.res.dto.ts
+++ b/src/apps/server/experiences/dto/res/getExperienceById.res.dto.ts
@@ -93,8 +93,7 @@ export class GetExperienceByIdResDto {
   @Exclude() _summaryKeywords: string[];
   @Exclude() _updatedAt: Date;
   @Exclude() _experienceInfo: GetExperienceInfoResDto;
-  @Exclude() _aiResume: string;
-  @Exclude() _aiCapabilities: string[];
+  @Exclude() _aiResume: AiResume;
 
   constructor(
     experience: Partial<
@@ -120,10 +119,7 @@ export class GetExperienceByIdResDto {
     this._summaryKeywords = experience.summaryKeywords;
     this._updatedAt = experience.updatedAt;
     this._experienceInfo = experience.ExperienceInfo;
-    this._aiResume = experience.AiResume.content;
-    this._aiCapabilities = experience.AiResume.AiResumeCapability.map(
-      (aiResumeCapability: AiResumeCapability) => aiResumeCapability.Capability.keyword,
-    );
+    this._aiResume = experience.AiResume;
   }
   @ApiProperty({ example: 1 })
   @IsOptionalNumber()
@@ -248,7 +244,7 @@ export class GetExperienceByIdResDto {
       },
     ],
   })
-  get AiResume(): string {
+  get AiResume(): AiResume {
     return this._aiResume;
   }
 
@@ -264,16 +260,5 @@ export class GetExperienceByIdResDto {
   })
   get ExperienceInfo(): GetExperienceInfoResDto {
     return this._experienceInfo;
-  }
-
-  @Expose()
-  @ApiPropertyOptional({
-    description: 'AI 직무 역량 키워드',
-    example: ['창의력', '협동력'],
-    type: String,
-    isArray: true,
-  })
-  get aiCapabilities(): string[] {
-    return this._aiCapabilities;
   }
 }

--- a/src/libs/modules/database/repositories/experience.repository.ts
+++ b/src/libs/modules/database/repositories/experience.repository.ts
@@ -3,7 +3,6 @@ import { PrismaService } from '../prisma.service';
 import { Experience, ExperienceInfo, ExperienceStatus } from '@prisma/client';
 import { ExperienceSelect } from '🔥apps/server/experiences/interface/experience-select.interface';
 import { ExperienceRepositoryInterface } from '🔥apps/server/experiences/interface/experience-repository.interface';
-import { ExperienceCardType } from '🔥apps/server/experiences/types/experience-card.type';
 import { PaginationOptionsDto } from '📚libs/pagination/pagination-option.dto';
 
 @Injectable()
@@ -26,6 +25,7 @@ export class ExperienceRepository implements ExperienceRepositoryInterface {
         summaryKeywords: true,
         updatedAt: true,
         ExperienceInfo: { select: { experienceId: true, experienceRole: true, motivation: true } },
+        ExperienceCapability: { select: { Capability: { select: { id: true, keyword: true, keywordType: true } } } },
         AiResume: {
           select: { content: true, AiResumeCapability: { select: { Capability: { select: { keyword: true, keywordType: true } } } } },
         },

--- a/src/libs/modules/open-ai/open-ai.service.ts
+++ b/src/libs/modules/open-ai/open-ai.service.ts
@@ -5,6 +5,7 @@ import { HttpService } from '@nestjs/axios';
 import { catchError, firstValueFrom } from 'rxjs';
 import { openAIModelEnum } from '📚libs/modules/open-ai/openAIModel.enum';
 import { AiResponse } from '📚libs/modules/open-ai/interface/aiResponse.interface';
+import { MINUTES } from '🔥apps/server/common/consts/time.const';
 
 @Injectable()
 export class OpenAiService {
@@ -32,7 +33,7 @@ export class OpenAiService {
     };
 
     const response = await firstValueFrom(
-      this.httpService.post(this.OPEN_AI_URL, data, { headers: this.openAIHeader }).pipe(
+      this.httpService.post(this.OPEN_AI_URL, data, { headers: this.openAIHeader, timeout: MINUTES * 1000 }).pipe(
         catchError((error) => {
           console.error(error.response.data);
           throw error;


### PR DESCRIPTION
## ⛳️ 기능 구현 배경

---

<!-- 기능 구현 배경에 대해 작성해주세요 -->

앞으로 카드 뒷면을 포함한 카드 데이터를 모두 보여주므로, experienceId를 통한 단일 조회에 뒷면 데이터에 쓰이는 직무 역량 키워드 속성 추가

## 😤 기능 구현 내용(Optional)

---

<!-- 기능 구현 내용에 대해 적어주세요 -->

### 경험 카드 조회

```ts
  public async getExperienceById(experienceId: number): Promise<Partial<Experience & { ExperienceInfo; AiResume }>> {
    return await this.prisma.experience.findUnique({
      where: { id: experienceId },
      select: {
        id: true,
        title: true,
        startDate: true,
        endDate: true,
        situation: true,
        task: true,
        action: true,
        result: true,
        experienceStatus: true,
        summaryKeywords: true,
        updatedAt: true,
        ExperienceInfo: { select: { experienceId: true, experienceRole: true, motivation: true } },
        ExperienceCapability: { select: { Capability: { select: { id: true, keyword: true, keywordType: true } } } }, // 직무 역량 키워드 가져오기 추가
        AiResume: {
          select: { content: true, AiResumeCapability: { select: { Capability: { select: { keyword: true, keywordType: true } } } } },
        },
      },
    });
  }
```

## 📭 이슈 번호

---

<!-- 이슈 번호를 남겨주세요 -->

#276 

## 🧐 의견 구하기

---

<!-- 구하고 싶은 의견이 있다면 작성해주세요 -->

```ts
  public async postAiKeywordPrompt(body: PromptAiKeywordBodyReqDto, user: UserJwtToken): Promise<PromptKeywordResDto> {
    await this.validationExperinece(body.experienceId, user.userId);
    const aiCapability = await this.prisma.aiResume.findUnique({
      where: { experienceId: body.experienceId },
      select: { AiResumeCapability: true },
    });
    if (aiCapability?.AiResumeCapability?.length) throw new ConflictException('이미 ai Capability가 존재합니다.');
```
이거 일단 빈배열인 경우를 대비해서 이렇게 바꾸긴 했는데, capability에 쌓이고 ai 자기소개서 추천을 안 받으면 계속해서 역량 키워드 생성 요청이 가능합니다. 이미 역량 키워드 분석을 했음에도 또 할 수가 있게 됩니다.

이거 외에도 요청을 모의로 보내보면서 조금.. 어색한 감이 없지 않아 있어서 데이터베이스를 수정할 필요가 있어 보이는데, 일단 당장 드는 생각으로는 keyword를 다시 ai가 추천해준 키워드, 유저가 직접 생성한 키워드로 나누고 ai 키워드 테이블과 experience 테이블을 1:N으로 설정하는 것입니다.

유저 < ai 키워드
유저 < 유저 키워드

경험 카드 < ai 키워드

ai 키워드 < ai 자기소개서 키워드 > ai 자기소개서

![image](https://github.com/depromeet/InsightOut-Server/assets/83271772/7db944e9-0be7-4fa5-92ae-456b9d936254)

버스 안이라서 글씨가 흔들려서 좀 이상한데 이런 구조입니다.

## 🙏 P.S

---

<!-- 추가적으로 남기고 싶은 말을 적어주세요 -->
