### PR TITLE
[#307] db 수정 및 SetNull변경

### DIFF
--- a/src/libs/modules/database/schema.prisma
+++ b/src/libs/modules/database/schema.prisma
@@ -151,10 +151,10 @@ model AiResume {
   updatedAt DateTime @updatedAt @map("updated_at") @db.Timestamptz // AI 자기소개서 수정 일자
 
   userId       Int @map("user_id")
-  experienceId Int @unique @map("experience_id") // 경험 id
+  experienceId Int? @unique @map("experience_id")  // 경험 id
 
   User                 User                 @relation(references: [id], fields: [userId], onDelete: Cascade)
-  Experience           Experience           @relation(references: [id], fields: [experienceId], onDelete: NoAction)
+  Experience           Experience?          @relation(references: [id], fields: [experienceId], onDelete: SetNull)
   AiResumeCapabilities AiResumeCapability[]
 
   @@map("ai_resumes")
@@ -205,6 +205,7 @@ model Experience {
   User                   User?                  @relation(references: [id], fields: [userId], onDelete: Cascade, onUpdate: Cascade)
   AiResume               AiResume?
   ExperienceInfo         ExperienceInfo?
+  Capabilities           Capability[]
   ExperienceCapabilities ExperienceCapability[]
   AiRecommendQuestions   AiRecommendQuestion[]
 
@@ -251,6 +252,7 @@ model Capability {
   experienceId Int?        @map("experience_id")
 
   User                   User                   @relation(references: [id], fields: [userId], onDelete: Cascade, onUpdate: Cascade)
+  Experience             Experience?            @relation(references: [id], fields: [experienceId], onDelete: SetNull)
   ExperienceCapabilities ExperienceCapability[]
   AiResumeCapabilities   AiResumeCapability[]
 


### PR DESCRIPTION
## ⛳️ 기능 구현 배경
- Experience 삭제 시 등장하는 에러를 해결했습니다.
---

<!-- 기능 구현 배경에 대해 작성해주세요 -->

## 😤 기능 구현 내용(Optional)
- experience와 capability를 1:N으로 연결했습니다.
- experience 삭제 시 capability의 experienceId가 null로 변경 되도록 cascade: SetNull구현했습니다.
- experience 삭제 시 aiResume의 experienceId가 null로 변경 되도록 cascade: SetNull구현했습니다.
---

<!-- 기능 구현 내용에 대해 적어주세요 -->

## 📭 이슈 번호
#307 
---

<!-- 이슈 번호를 남겨주세요 -->

## 🧐 의견 구하기

---

<!-- 구하고 싶은 의견이 있다면 작성해주세요 -->

## 🙏 P.S

---

<!-- 추가적으로 남기고 싶은 말을 적어주세요 -->
