### PR TITLE
[Fix] 경험카드 단일 조회에서 AI 자기소개서 추천 문항을 반환하도록 수정

### DIFF
--- a/src/apps/server/experiences/dto/res/getExperienceById.res.dto.ts
+++ b/src/apps/server/experiences/dto/res/getExperienceById.res.dto.ts
@@ -1,5 +1,5 @@
 import { Exclude, Expose, Type } from 'class-transformer';
-import { Experience, ExperienceCapability, ExperienceStatus, KeywordType } from '@prisma/client';
+import { AiRecommendQuestion, Experience, ExperienceCapability, ExperienceStatus, KeywordType } from '@prisma/client';
 import {
   ArrayMaxSize,
   ArrayMinSize,
@@ -94,6 +94,7 @@ export class GetExperienceByIdResDto {
   @Exclude() _updatedAt: Date;
   @Exclude() _ExperienceInfo: GetExperienceInfoResDto;
   @Exclude() _AiResume: AiResume;
+  @Exclude() _AiRecommendQuestions: Omit<AiRecommendQuestion, 'experienceId'>[];
 
   constructor(
     experience: Partial<
@@ -101,6 +102,7 @@ export class GetExperienceByIdResDto {
         ExperienceInfo: GetExperienceInfoResDto;
         AiResume: AiResume;
         ExperienceCapabilities: (Partial<ExperienceCapability> & { Capability: Capability })[];
+        AiRecommendQuestions: AiRecommendQuestion[];
       }
     >,
   ) {
@@ -120,6 +122,11 @@ export class GetExperienceByIdResDto {
     this._updatedAt = experience.updatedAt;
     this._ExperienceInfo = experience.ExperienceInfo;
     this._AiResume = experience.AiResume;
+    this._AiRecommendQuestions = experience.AiRecommendQuestions.map((aiRecommendQuestion) => {
+      const { experienceId, ...rest } = aiRecommendQuestion;
+
+      return rest;
+    });
   }
   @ApiProperty({ example: 1 })
   @IsOptionalNumber()
@@ -260,5 +267,28 @@ export class GetExperienceByIdResDto {
   })
   get ExperienceInfo(): GetExperienceInfoResDto {
     return this._ExperienceInfo;
+  }
+
+  @Expose()
+  @ApiPropertyOptional({
+    description: '경험카드 하단의 ai 자기소개서 추천 문항입니다.',
+    example: [
+      {
+        id: 3,
+        title: '본인이 어떤 어려운 상황에서 빠르게 대응하여 성공을 이룬 경험에 대해 이야기해 주세요.',
+        createdAt: '2023-07-16T12:06:29.062Z',
+        updatedAt: '2023-07-16T12:06:29.062Z',
+      },
+      {
+        id: 4,
+        title: '본인이 성공을 위해 여러 가지 어려움을 극복한 과정에 대해 설명해 주세요.',
+        createdAt: '2023-07-16T12:06:29.062Z',
+        updatedAt: '2023-07-16T12:06:29.062Z',
+      },
+    ],
+    isArray: true,
+  })
+  get AiRecommendQuestions(): Omit<AiRecommendQuestion, 'experienceId'>[] {
+    return this._AiRecommendQuestions;
   }
 }

--- a/src/libs/modules/database/repositories/experience.repository.ts
+++ b/src/libs/modules/database/repositories/experience.repository.ts
@@ -29,6 +29,7 @@ export class ExperienceRepository implements ExperienceRepositoryInterface {
         AiResume: {
           select: { content: true, AiResumeCapabilities: { select: { Capability: { select: { keyword: true } } } } },
         },
+        AiRecommendQuestions: true,
       },
     });
   }


### PR DESCRIPTION
## ⛳️ 기능 구현 배경

---

<!-- 기능 구현 배경에 대해 작성해주세요 -->

경험카드 다중 조회에서는 ai 자기소개서 추천 문항이 있지만, ai 단일 조회에는 없어서 추가했습니다.

## 😤 기능 구현 내용(Optional)

---

<!-- 기능 구현 내용에 대해 적어주세요 -->

## 📭 이슈 번호

---

<!-- 이슈 번호를 남겨주세요 -->

#311 

## 🧐 의견 구하기

---

<!-- 구하고 싶은 의견이 있다면 작성해주세요 -->

## 🙏 P.S

---

<!-- 추가적으로 남기고 싶은 말을 적어주세요 -->
