### PR TITLE
[Fix] 경험 카드 키워드 로직 수정

### DIFF
--- a/src/apps/server/experiences/services/experience.service.ts
+++ b/src/apps/server/experiences/services/experience.service.ts
@@ -206,10 +206,10 @@ export class ExperienceService {
   ): Promise<GetCountOfExperienceAndCapabilityResponseDto[]> {
     let countOfExperienceAndCapability = await this.capabilityRepository.countExperienceAndCapability(userId, isCompleted);
     countOfExperienceAndCapability = countOfExperienceAndCapability.filter((experienceAndCapability) => {
-      const validExperienceAndCapability = experienceAndCapability.ExperienceCapabilities.filter((ExperienceCapability) =>
+      const validExperienceAndCapability = experienceAndCapability.ExperienceCapabilities.map((ExperienceCapability) =>
         this.checkExperienceIsValid(ExperienceCapability.Experience),
       );
-      return validExperienceAndCapability.length > 0;
+      return validExperienceAndCapability.length > 0 && validExperienceAndCapability;
     });
 
     // 전체(경험카드 개수)를 가져오기 위한 count문 만들기 >> ID를 0으로 넣자

--- a/src/apps/server/experiences/services/experience.service.ts
+++ b/src/apps/server/experiences/services/experience.service.ts
@@ -213,12 +213,12 @@ export class ExperienceService {
     });
 
     // 전체(경험카드 개수)를 가져오기 위한 count문 만들기 >> ID를 0으로 넣자
-    const experienceCountByIsCompleted = await this.experienceRepository.getCountByIsCompleted(userId, isCompleted);
+    const totalCountOfCapabilities = countOfExperienceAndCapability.reduce((prev, curr) => prev + curr._count.ExperienceCapabilities, 0);
 
     countOfExperienceAndCapability.unshift({
       id: 0,
       keyword: '전체',
-      _count: { ExperienceCapabilities: experienceCountByIsCompleted },
+      _count: { ExperienceCapabilities: totalCountOfCapabilities },
     } as unknown as CountExperienceAndCapability);
 
     // count가 0인 키워드는 필터링합니다.

--- a/src/libs/modules/database/repositories/capability.repository.ts
+++ b/src/libs/modules/database/repositories/capability.repository.ts
@@ -19,7 +19,7 @@ export class CapabilityRepository extends AbstractRepository<
   public async countExperienceAndCapability(userId: number, isCompleted?: boolean): Promise<CountExperienceAndCapability[]> {
     const where = <Prisma.CapabilityWhereInput>{ userId };
     if (isCompleted === true) {
-      where.ExperienceCapabilities = { every: { Experience: { is: { experienceStatus: ExperienceStatus.DONE } } } };
+      where.ExperienceCapabilities = { some: { Experience: { is: { experienceStatus: ExperienceStatus.DONE } } } };
     }
 
     return (await this.findMany({

--- a/src/libs/modules/database/repositories/experience.repository.ts
+++ b/src/libs/modules/database/repositories/experience.repository.ts
@@ -166,16 +166,30 @@ export class ExperienceRepository implements ExperienceRepositoryInterface {
 
     experiences = experiences.filter((experience) => {
       if (experience.experienceStatus === ExperienceStatus.DONE) {
-        return (
+        let isValidExperience =
           experience.title &&
-          experience.situation &&
-          experience.task &&
-          experience.action &&
-          experience.result &&
           experience.startDate instanceof Date &&
           experience.endDate instanceof Date &&
-          experience.ExperienceCapabilities.length
-        );
+          experience.ExperienceCapabilities.length &&
+          true;
+
+        if (select.situation) {
+          isValidExperience = experience.situation && isValidExperience;
+        }
+
+        if (select.task) {
+          isValidExperience = experience.task && isValidExperience;
+        }
+
+        if (select.action) {
+          isValidExperience = experience.action && isValidExperience;
+        }
+
+        if (select.result) {
+          isValidExperience = experience.result && isValidExperience;
+        }
+
+        return isValidExperience;
       }
       return true;
     });


### PR DESCRIPTION
## ⛳️ 기능 구현 배경

---

<!-- 기능 구현 배경에 대해 작성해주세요 -->

situation, task, action, result에 상관 없이 모두 있는지 체크하느라 에러가 발생해서, 쿼리로 들어온 애들만 조건문을 통해 걸러냈습니다.

## 😤 기능 구현 내용(Optional)

---

<!-- 기능 구현 내용에 대해 적어주세요 -->

- 경험카드 필터링 수정

```ts
    experiences = experiences.filter((experience) => {
      if (experience.experienceStatus === ExperienceStatus.DONE) {
        let isValidExperience =
          experience.title &&
          experience.startDate instanceof Date &&
          experience.endDate instanceof Date &&
          experience.ExperienceCapabilities.length &&
          true;

        if (select.situation) {
          isValidExperience = experience.situation && isValidExperience;
        }

        if (select.task) {
          isValidExperience = experience.task && isValidExperience;
        }

        if (select.action) {
          isValidExperience = experience.action && isValidExperience;
        }

        if (select.result) {
          isValidExperience = experience.result && isValidExperience;
        }

        return isValidExperience;
      }
      return true;
    });
```

- 경험 카드 개수 가져오는 count문 수정

```ts
// 전체(경험카드 개수)를 가져오기 위한 count문 만들기 >> ID를 0으로 넣자
    const totalCountOfCapabilities = countOfExperienceAndCapability.reduce((prev, curr) => prev + curr._count.ExperienceCapabilities, 0);

    countOfExperienceAndCapability.unshift({
      id: 0,
      keyword: '전체',
      _count: { ExperienceCapabilities: totalCountOfCapabilities },
    } as unknown as CountExperienceAndCapability);
```

## 📭 이슈 번호

---

<!-- 이슈 번호를 남겨주세요 -->

#325 

## 🧐 의견 구하기

---

<!-- 구하고 싶은 의견이 있다면 작성해주세요 -->

## 🙏 P.S

---

<!-- 추가적으로 남기고 싶은 말을 적어주세요 -->
