### PR TITLE
[Fix] 경험분해 페이지네이션 개수 조회 수정

### DIFF
--- a/src/apps/server/experiences/services/experience.service.ts
+++ b/src/apps/server/experiences/services/experience.service.ts
@@ -155,7 +155,7 @@ export class ExperienceService {
       (experience) => new GetExperiencesResponseDto(experience),
     );
 
-    const itemCount = await this.experienceRepository.getCount(userId);
+    const itemCount = await this.experienceRepository.getCount(userId, select, capabilityId);
 
     const experienceDto = new PaginationDto(
       getExperienceByCapabilityResponseDto,

--- a/src/libs/modules/database/repositories/experience.repository.ts
+++ b/src/libs/modules/database/repositories/experience.repository.ts
@@ -66,8 +66,9 @@ export class ExperienceRepository implements ExperienceRepositoryInterface {
     });
   }
 
-  public async getCount(userId: number) {
-    return await this.prisma.experience.count({ where: { userId } });
+  public async getCount(userId: number, select: Partial<ExperienceSelect>, capabilityId?: number) {
+    const experiences = await this.getExperiences(userId, select, { skip: undefined, take: undefined }, capabilityId);
+    return experiences.length;
   }
 
   public async getCountByIsCompleted(userId: number, isCompleted: boolean) {


### PR DESCRIPTION
## ⛳️ 기능 구현 배경

---

<!-- 기능 구현 배경에 대해 작성해주세요 -->

경험분해 페이지네이션에서 총 itemCount로 NextPage와 PreviousPage를 찾는데, itemCount 자체에서 유효성 검사로 로직이 불가능해져서 새로 고쳤습니다.

## 😤 기능 구현 내용(Optional)

---

<!-- 기능 구현 내용에 대해 적어주세요 -->

```ts
  public async getCount(userId: number, select: Partial<ExperienceSelect>, capabilityId?: number) {
    const experiences = await this.getExperiences(userId, select, { skip: undefined, take: undefined }, capabilityId);
    return experiences.length;
  }
```

## 📭 이슈 번호

---

<!-- 이슈 번호를 남겨주세요 -->

#314 

## 🧐 의견 구하기

---

<!-- 구하고 싶은 의견이 있다면 작성해주세요 -->

count로 가져오는 건 캐싱해서 써도 괜찮을 것 같다가도 저장하는 데이터가 많으니까 불안불안쓰 하군요..

나중에 ElasticCache 써서 redis 관리는 AWS에 위임시키는 것도 좋을 듯 합니다~

## 🙏 P.S

---

<!-- 추가적으로 남기고 싶은 말을 적어주세요 -->
