### PR TITLE
Feature/#353/modify experience

### DIFF
--- a/src/apps/server/experiences/dto/req/updateExperience.dto.ts
+++ b/src/apps/server/experiences/dto/req/updateExperience.dto.ts
@@ -1,6 +1,6 @@
 import { ApiPropertyOptional } from '@nestjs/swagger';
-import { Experience, ExperienceInfo, ExperienceStatus } from '@prisma/client';
-import { IsEnum, IsOptional, Matches } from 'class-validator';
+import { AiResume, Experience, ExperienceInfo, ExperienceStatus } from '@prisma/client';
+import { IsEnum, IsNotEmpty, IsOptional, IsString, Matches } from 'class-validator';
 
 import { dateValidation } from '@apps/server/common/consts/dateValidation.const';
 import { IsOptionalString } from '@apps/server/common/decorators/validations/isCustomString.decorator';
@@ -65,7 +65,16 @@ export class UpdateExperienceRequestDto {
   // 키워드 요약 후 저장할 떄 필요하기 떄문입니다 :)
   summaryKeywords?: string[];
 
-  public compareProperty(experience: Experience & { ExperienceInfo?: ExperienceInfo }) {
+  @ApiPropertyOptional({
+    description: 'AI 추천 자기소개서',
+    type: String,
+  })
+  @IsString()
+  @IsNotEmpty()
+  @IsOptional()
+  aiResume: string;
+
+  public compareProperty(experience: Experience & { ExperienceInfo?: ExperienceInfo; AiResume: AiResume }) {
     if (this.title) experience.title = this.title;
     if (this.startDate) experience.startDate = new Date(this.startDate);
     if (this.endDate) experience.endDate = new Date(this.endDate);
@@ -78,6 +87,13 @@ export class UpdateExperienceRequestDto {
     if (this.experienceRole) experience.ExperienceInfo.experienceRole = this.experienceRole;
     if (this.motivation) experience.ExperienceInfo.motivation = this.motivation;
     if (this.analysis) experience.ExperienceInfo.analysis = this.analysis;
+    if (this.aiResume)
+      experience.AiResume = {
+        ...experience.AiResume,
+        experienceId: experience.id,
+        userId: experience.userId,
+        content: this.aiResume,
+      };
 
     return experience;
   }

--- a/src/apps/server/experiences/dto/res/updateExperienceInfo.dto.ts
+++ b/src/apps/server/experiences/dto/res/updateExperienceInfo.dto.ts
@@ -1,7 +1,7 @@
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
-import { Experience, ExperienceInfo, ExperienceStatus } from '@prisma/client';
-import { Exclude, Expose } from 'class-transformer';
-import { IsEnum, IsOptional, Matches } from 'class-validator';
+import { AiResume, Experience, ExperienceInfo, ExperienceStatus } from '@prisma/client';
+import { Exclude, Expose, Type } from 'class-transformer';
+import { IsEnum, IsInt, IsObject, IsOptional, IsPositive, IsString, Matches, ValidateNested } from 'class-validator';
 
 import { dateValidation } from '@apps/server/common/consts/dateValidation.const';
 import { IsOptionalNumber } from '@apps/server/common/decorators/validations/isCustomNumber.decorator';
@@ -60,6 +60,40 @@ export class UpdateExperienceInfoResponseDto {
   }
 }
 
+export class UpdateAiResumeResponseDto {
+  @Exclude() private readonly _aiResumeId: number;
+  @Exclude() private readonly _content: string;
+
+  constructor({ id: aiResumeId, content }: AiResume) {
+    this._aiResumeId = aiResumeId;
+    this._content = content;
+  }
+
+  @ApiProperty({
+    description: 'ai 추천 자기소개서 id',
+    example: 1,
+    type: Number,
+  })
+  @IsInt()
+  @IsPositive()
+  @IsOptional()
+  @Expose()
+  get aiResumeId(): number {
+    return this._aiResumeId;
+  }
+
+  @ApiProperty({
+    description: 'ai 추천 자기소개서 내용',
+    type: String,
+  })
+  @IsString()
+  @IsOptional()
+  @Expose()
+  get content(): string {
+    return this._content;
+  }
+}
+
 export class UpdateExperienceResDto {
   @Exclude() private readonly _experienceId: number;
   @Exclude() private readonly _title: string;
@@ -71,8 +105,9 @@ export class UpdateExperienceResDto {
   @Exclude() private readonly _endDate: Date;
   @Exclude() private readonly _experienceStatus: ExperienceStatus;
   @Exclude() private readonly _experienceInfo: UpdateExperienceInfoResponseDto;
+  @Exclude() private readonly _aiResume: UpdateAiResumeResponseDto;
 
-  constructor(experience: Experience, experienceInfo: ExperienceInfo) {
+  constructor(experience: Experience, experienceInfo: ExperienceInfo, aiResume: AiResume) {
     this._experienceId = experience.id;
     this._title = experience.title;
     this._startDate = experience.startDate;
@@ -90,6 +125,7 @@ export class UpdateExperienceResDto {
     experienceInfoRes.setAnalysis = experienceInfo.analysis;
 
     this._experienceInfo = experienceInfoRes;
+    this._aiResume = new UpdateAiResumeResponseDto(aiResume);
   }
 
   @ApiProperty({ example: 1 })
@@ -156,6 +192,15 @@ export class UpdateExperienceResDto {
   @Expose()
   get experienceInfo(): UpdateExperienceInfoResponseDto {
     return this._experienceInfo;
+  }
+
+  @ApiProperty({ description: 'ai 추천 자기소개서', type: UpdateAiResumeResponseDto })
+  @IsObject()
+  @ValidateNested()
+  @Type(() => UpdateAiResumeResponseDto)
+  @Expose()
+  get aiResume(): UpdateAiResumeResponseDto {
+    return this._aiResume;
   }
 }
 

--- a/src/apps/server/experiences/services/experience.service.ts
+++ b/src/apps/server/experiences/services/experience.service.ts
@@ -175,9 +175,10 @@ export class ExperienceService {
     id: number,
     updatedExperienceInfo: Experience & {
       ExperienceInfo?: ExperienceInfo;
+      AiResume?: AiResume;
     },
   ): Promise<UpdateExperienceResDto> {
-    const [experience, experienceInfo] = await this.prisma.$transaction(async (tx) => {
+    const [experience, experienceInfo, aiResume] = await this.prisma.$transaction(async (tx) => {
       const experienceInfo = await tx.experienceInfo.update({
         where: { experienceId: id },
         data: {
@@ -201,9 +202,16 @@ export class ExperienceService {
           summaryKeywords: updatedExperienceInfo.summaryKeywords,
         },
       });
-      return [experience, experienceInfo];
+
+      const aiResume = await tx.aiResume.upsert({
+        where: { experienceId: id },
+        create: updatedExperienceInfo.AiResume,
+        update: updatedExperienceInfo.AiResume,
+      });
+
+      return [experience, experienceInfo, aiResume];
     });
-    return new UpdateExperienceResDto(experience, experienceInfo);
+    return new UpdateExperienceResDto(experience, experienceInfo, aiResume);
   }
 
   public async getCountOfExperienceAndCapability(


### PR DESCRIPTION
## ⛳️ 기능 구현 배경

---

<!-- 기능 구현 배경에 대해 작성해주세요 -->

<img width="1078" alt="image" src="https://github.com/depromeet/InsightOut-Server/assets/83271772/b7e300be-58c6-43ad-82d0-1f4b00f8023a">

상범님께서 ai 자기소개서를 받아오는 기능을 프론트에서 구현해주셔서, 이 자기소개서 내용을 백엔드로 저장하는 api가 필요했습니다.


## 😤 기능 구현 내용(Optional)

---

<!-- 기능 구현 내용에 대해 적어주세요 -->

```ts
      const aiResume = await tx.aiResume.upsert({
        where: { experienceId: id },
        create: updatedExperienceInfo.AiResume,
        update: updatedExperienceInfo.AiResume,
      });

      return [experience, experienceInfo, aiResume];
```

aiResume는 생겼을 수도 있고, 안 생겼을 수도 있으므로 upsert를 사용했습니다.

## 📭 이슈 번호

---

<!-- 이슈 번호를 남겨주세요 -->

#353 

## 🧐 의견 구하기

---

<!-- 구하고 싶은 의견이 있다면 작성해주세요 -->

요청하신지 좀 돼서,,,, 빠르게 반영하면 좋을 것 같습니다!

## 🙏 P.S

---

<!-- 추가적으로 남기고 싶은 말을 적어주세요 -->
